### PR TITLE
Added MCO2 Page

### DIFF
--- a/src/abis/erc20.json
+++ b/src/abis/erc20.json
@@ -1,0 +1,222 @@
+[
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "name",
+        "outputs": [
+            {
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "name": "_spender",
+                "type": "address"
+            },
+            {
+                "name": "_value",
+                "type": "uint256"
+            }
+        ],
+        "name": "approve",
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "name": "_from",
+                "type": "address"
+            },
+            {
+                "name": "_to",
+                "type": "address"
+            },
+            {
+                "name": "_value",
+                "type": "uint256"
+            }
+        ],
+        "name": "transferFrom",
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [
+            {
+                "name": "_owner",
+                "type": "address"
+            }
+        ],
+        "name": "balanceOf",
+        "outputs": [
+            {
+                "name": "balance",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [
+            {
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "name": "_to",
+                "type": "address"
+            },
+            {
+                "name": "_value",
+                "type": "uint256"
+            }
+        ],
+        "name": "transfer",
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [
+            {
+                "name": "_owner",
+                "type": "address"
+            },
+            {
+                "name": "_spender",
+                "type": "address"
+            }
+        ],
+        "name": "allowance",
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "payable": true,
+        "stateMutability": "payable",
+        "type": "fallback"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Approval",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Transfer",
+        "type": "event"
+    }
+]

--- a/src/apps/tco2_dashboard/assets/styles.css
+++ b/src/apps/tco2_dashboard/assets/styles.css
@@ -181,6 +181,30 @@ color: white;
   background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='rgba(192, 192, 192, 0.3)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
 }
 
+._dash-loading {
+  margin: auto;
+  color: transparent;
+  width: 0;
+  height: 0;
+  text-align: center;
+}
+
+._dash-loading::after {
+  content: '';
+  display: inline-block;
+  width: 2rem;
+  height: 2rem;
+  color: black;
+  vertical-align: text-bottom;
+  border: 0.25em solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  -webkit-animation: spinner-border 0.75s linear infinite;
+  animation: spinner-border 0.75s linear infinite;
+  margin-top: 2rem;
+}
+
+
 @media (min-width: 48em) {
   #sidebar {
     position: fixed;

--- a/src/apps/tco2_dashboard/constants.py
+++ b/src/apps/tco2_dashboard/constants.py
@@ -3,6 +3,7 @@ BCT_ADDRESS = '0x2f800db0fdb5223b3c3f354886d907a671414a7f'
 GRAY = '#232B2B'
 DARK_GRAY = '#343a40'
 FIGURE_BG_COLOR = '#202020'
+MCO2_ADDRESS = '0xfC98e825A2264D890F9a1e68ed50E1526abCcacD'
 
 rename_map = {
     'carbonOffsets_bridges_value': 'Quantity',
@@ -75,3 +76,9 @@ verra_rename_map = {
 
 merge_columns = ["ID", "Name", "Region", "Country",
                  "Project Type", "Methodology", "Toucan"]
+
+
+mco2_verra_rename_map = {
+    'Project Name': 'Name',
+    'Quantity of Credits': 'Quantity',
+}

--- a/src/apps/tco2_dashboard/figures.py
+++ b/src/apps/tco2_dashboard/figures.py
@@ -282,6 +282,28 @@ def project_volume(df, zero_evt_text):
     return fig
 
 
+def project_volume_mco2(df, zero_evt_text):
+    df = df[df['Project Type'] != "missing"].reset_index(drop=True)
+    if not(df.empty):
+        fig = px.treemap(df, path=[px.Constant("All Projects"), 'Project Type', 'Name'], values='Quantity',
+                         hover_data=['Name', 'Quantity'],
+                         height=300, title='')
+        fig.update_traces(textfont=dict(color='white'),
+                          textinfo="label+value+percent parent+percent entry+percent root",
+                          texttemplate='<br>'.join(['%{label}', 'Quantity=%{value}', '%{percentParent} of Parent',
+                                                    '%{percentEntry} of Entry', '%{percentRoot} of Root']))
+        fig.update_layout(paper_bgcolor=FIGURE_BG_COLOR, plot_bgcolor=FIGURE_BG_COLOR, font=dict(color='white'),
+                          hoverlabel=dict(font_color='white', font_size=8), font_size=12,
+                          margin=dict(t=20, b=20, l=0, r=0))
+    else:
+        fig = go.Figure()
+        fig.update_layout(height=300, paper_bgcolor=FIGURE_BG_COLOR, plot_bgcolor=FIGURE_BG_COLOR,
+                          xaxis=dict(visible=False), yaxis=dict(visible=False),
+                          annotations=[dict(text=zero_evt_text,
+                                            font=dict(color='white'), showarrow=False)])
+    return fig
+
+
 def pool_pie_chart(df):
     labels = ['BCT', 'NCT', 'Not Pooled']
     BCT = df['BCT Quantity'].sum()

--- a/src/apps/tco2_dashboard/get_data.py
+++ b/src/apps/tco2_dashboard/get_data.py
@@ -1,0 +1,5 @@
+import pandas as pd
+
+df = pd.read_csv('http://raw.githubusercontent.com/originalpkbims/dash-apps/main/src/apps/tco2_dashboard/mco2_verra_data.csv')
+
+print(df)

--- a/src/apps/tco2_dashboard/get_data.py
+++ b/src/apps/tco2_dashboard/get_data.py
@@ -1,5 +1,0 @@
-import pandas as pd
-
-df = pd.read_csv('http://raw.githubusercontent.com/originalpkbims/dash-apps/main/src/apps/tco2_dashboard/mco2_verra_data.csv')
-
-print(df)

--- a/src/apps/tco2_dashboard/helpers.py
+++ b/src/apps/tco2_dashboard/helpers.py
@@ -93,9 +93,7 @@ def subsets(df):
 
     # 7-day, last 7-day, 30-day and last 30 day time
     current_time = dt.datetime.combine(dt.date.today(), dt.datetime.min.time())
-    print(current_time)
     seven_day_start = current_time - dt.timedelta(days=7)
-    print(seven_day_start)
     last_seven_day_start = seven_day_start - dt.timedelta(days=7)
     thirty_day_start = current_time - dt.timedelta(days=30)
     last_thirty_day_start = thirty_day_start - dt.timedelta(days=30)
@@ -129,6 +127,24 @@ def verra_manipulations(df_verra):
     return df_verra, df_verra_toucan
 
 
+def mco2_verra_manipulations(df_mco2_bridged):
+    df_mco2_bridged = df_mco2_bridged[[
+        "Project ID", "Vintage", "Quantity", "Project Type", "Name"]]
+    df_mco2_bridged["Vintage"] = pd.to_datetime(
+        df_mco2_bridged["Vintage"].str[6:10]).dt.tz_localize(None).dt.year
+    df_mco2_bridged["Quantity"] = df_mco2_bridged["Quantity"].astype(int)
+    df_mco2_bridged["Project ID"] = 'VCS-' + \
+        df_mco2_bridged["Project ID"].astype(str)
+
+    pat = r'VCS-(?P<id>\d+)'
+    repl = (
+        lambda m: '[VCS-' + m.group(
+            'id') + '](https://registry.verra.org/app/projectDetail/VCS/' + m.group('id') + ')')
+    df_mco2_bridged['Project ID'] = df_mco2_bridged['Project ID'].astype(str).str.replace(
+        pat, repl, regex=True)
+    return df_mco2_bridged
+
+
 def filter_carbon_pool(pool_address, *dfs):
     filtered = []
     for df in dfs:
@@ -140,10 +156,9 @@ def filter_carbon_pool(pool_address, *dfs):
 def filter_pool_quantity(df, quantity_column):
     filtered = df[df[quantity_column] > 0]
     filtered = filtered[[
-        'Project ID', 'Vintage', quantity_column, 'Region', 'Name', 'Project Type',
+        'Project ID', 'Vintage', quantity_column, 'Country', 'Name', 'Project Type',
         'Methodology', 'Token Address'
     ]]
-
     pat = r'VCS-(?P<id>\d+)'
     repl = (
         lambda m: '[VCS-' + m.group(

--- a/src/apps/tco2_dashboard/mco2.py
+++ b/src/apps/tco2_dashboard/mco2.py
@@ -1,0 +1,86 @@
+from dash import html, dash_table
+from dash import dcc
+import dash_bootstrap_components as dbc
+from .constants import GRAY, DARK_GRAY
+
+
+def create_content_moss(df_mco2_bridged, fig_mco2_total_vintage, fig_mco2_total_project, current_supply):
+    content_mco2 = [
+        dbc.Row(
+            dbc.Col(
+                dbc.Card([
+                    dbc.CardHeader(
+                        html.H1("State of MOSS Tokenized Carbon", className='page-title'))
+                ]), width=12, style={'textAlign': 'center'})
+        ),
+
+        dbc.Row([
+            dbc.Col(dbc.Card([
+                html.H5("MCO2 Tonnes Bridged", className="card-title"),
+                dbc.CardBody("{:,}".format(
+                    int(df_mco2_bridged["Quantity"].sum())), className="card-text")
+            ]), lg=4, md=12),
+            dbc.Col(dbc.Card([
+                html.H5("MCO2 Tonnes Retired", className="card-title"),
+                dbc.CardBody("{:,}".format(
+                    int(df_mco2_bridged["Quantity"].sum() - current_supply)), className="card-text")
+            ]), lg=4, md=12),
+            dbc.Col(dbc.Card([
+                html.H5("MCO2 Tonnes Outstanding",
+                        className="card-title"),
+                dbc.CardBody("{:,}".format(
+                    int(current_supply)), className="card-text")
+            ]), lg=4, md=12),
+        ], style={'paddingTop': '60px'}),
+
+        dbc.Row([
+            dbc.Col(),
+            dbc.Col(dbc.Card([
+                dbc.CardBody(html.H2('Deep Dive into Bridged MCO2'),
+                             style={'textAlign': 'center'})
+            ]), lg=6, md=12),
+            dbc.Col(),
+        ], style={'paddingTop': '60px'}),
+
+        dbc.Row([
+            dbc.Col(),
+            dbc.Col(dbc.Card([
+                html.H5("Distribution of Vintage Start Dates",
+                        className="card-title"),
+                dcc.Graph(figure=fig_mco2_total_vintage)
+            ]), width=12),
+            dbc.Col(),
+        ]),
+
+        dbc.Row([
+            dbc.Col(),
+            dbc.Col(dbc.Card([
+                html.H5("Distribution of Projects", className="card-title"),
+                dcc.Graph(figure=fig_mco2_total_project)
+            ]), width=12),
+            dbc.Col(),
+        ]),
+        dbc.Row([
+            dbc.Col([
+                dbc.Card([
+                    html.H5('MCO2 Composition Details', className="card-title"),
+                    dash_table.DataTable(
+                        df_mco2_bridged.to_dict('records'),
+                        [{"name": i, "id": i, "presentation": "markdown"} for i in df_mco2_bridged.columns],
+                        id='tbl',
+                        style_header={
+                            'backgroundColor': GRAY,
+                            'text-align': 'center'
+                        },
+                        style_data={
+                            'backgroundColor': DARK_GRAY
+                        },
+                        style_table={'overflowX': 'auto'},
+                        page_size=20,
+                        sort_action='native'
+                    ),
+                ])
+            ])
+        ])
+    ]
+    return content_mco2

--- a/src/apps/tco2_dashboard/pool.py
+++ b/src/apps/tco2_dashboard/pool.py
@@ -65,7 +65,8 @@ def create_pool_content(pool_ticker, pool_name, deposited, redeemed, detail_df, 
                         [{"name": i, "id": i, "presentation": "markdown"} for i in detail_df.columns],
                         id='tbl',
                         style_header={
-                            'backgroundColor': GRAY
+                            'backgroundColor': GRAY,
+                            'text-align': 'center'
                         },
                         style_data={
                             'backgroundColor': DARK_GRAY


### PR DESCRIPTION
In this PR I have:

1) Imported **MCO2 Verra Registry** reports by importing data from a csv saved on my originalpkbims fork, we can bring in the file here once you approve this idea of importing MCO2 Verra data. https://mco2token.moss.earth/#:~:text=supply%20info%20here%3A-,The,-following%20are%20the

2)Imported **total supply** using **Infura**

3) Created a new page and added summary cards, graphs and detail table

Next steps;

- Add Moss ETH contract to carbon subgraphs so that we can get real-time bridged and retired info.




