### PR TITLE
On vs off retirements

### DIFF
--- a/src/apps/tco2_dashboard/app.py
+++ b/src/apps/tco2_dashboard/app.py
@@ -14,7 +14,8 @@ from pycoingecko import CoinGeckoAPI
 from ...util import get_eth_web3, load_abi
 from .figures import sub_plots_vintage, sub_plots_volume, map, total_vintage, total_volume, \
     methodology_volume, project_volume, eligible_pool_pie_chart, pool_pie_chart,\
-    historical_prices, bridges_pie_chart, on_vs_off_vintage, on_vs_off_map, on_vs_off_project
+    historical_prices, bridges_pie_chart, on_vs_off_vintage, on_vs_off_map, on_vs_off_project,\
+    tokenized_volume, on_vs_off_vintage_retired, on_vs_off_map_retired, on_vs_off_project_retired
 from .figures_carbon_pool import deposited_over_time, redeemed_over_time, retired_over_time
 from .offchain_vs_onchain import create_offchain_vs_onchain_content
 from .onchain_pool_comp import create_onchain_pool_comp_content
@@ -24,15 +25,18 @@ from .pool import create_pool_content
 from .mco2 import create_content_moss
 from .helpers import date_manipulations, filter_pool_quantity, region_manipulations, \
     subsets, drop_duplicates, filter_carbon_pool, bridge_manipulations, \
-    merge_verra, verra_manipulations, mco2_verra_manipulations, read_csv
+    merge_verra, verra_manipulations, mco2_verra_manipulations, \
+    adjust_mco2_bridges, verra_retired, date_manipulations_verra
 from .constants import rename_map, retires_rename_map, deposits_rename_map, \
     redeems_rename_map, pool_retires_rename_map, BCT_ADDRESS, \
-    verra_rename_map, merge_columns, mco2_verra_rename_map, MCO2_ADDRESS, verra_columns, \
+    verra_rename_map, merge_columns, MCO2_ADDRESS, verra_columns, \
     VERRA_FALLBACK_NOTE, VERRA_FALLBACK_URL, NCT_ADDRESS, KLIMA_RETIRED_NOTE, UBO_ADDRESS, \
-    NBO_ADDRESS
+    NBO_ADDRESS, mco2_bridged_rename_map, bridges_rename_map
 
 CACHE_TIMEOUT = 86400
 CARBON_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/klimadao/polygon-bridged-carbon'
+CARBON_MOSS_ETH_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/originalpkbims/ethcarbonsubgraph'
+CARBON_ETH_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/originalpkbims/ethereum-bridged-carbon'
 MAX_RECORDS = 1000000
 PRICE_DAYS = 5000
 GOOGLE_API_ICONS = {
@@ -65,6 +69,7 @@ cache = Cache(app.server, config={
 })
 
 
+@cache.memoize()
 def get_data():
 
     sg = Subgrounds()
@@ -120,6 +125,7 @@ def get_data():
     return df_bridged, df_retired
 
 
+@cache.memoize()
 def get_data_pool():
 
     sg = Subgrounds()
@@ -150,6 +156,7 @@ def get_data_pool():
     return df_deposited, df_redeemed
 
 
+@cache.memoize()
 def get_data_pool_retired():
 
     sg = Subgrounds()
@@ -168,6 +175,72 @@ def get_data_pool_retired():
     return df_pool_retired
 
 
+def get_mco2_data():
+    sg = Subgrounds()
+
+    carbon_data = sg.load_subgraph(CARBON_MOSS_ETH_SUBGRAPH_URL)
+    carbon_offsets = carbon_data.Query.batches(
+        first=MAX_RECORDS
+    )
+    df_bridged = sg.query_df([
+        carbon_offsets.id,
+        carbon_offsets.serialNumber,
+        carbon_offsets.timestamp,
+        carbon_offsets.tokenAddress,
+        carbon_offsets.vintage,
+        carbon_offsets.projectID,
+        carbon_offsets.value,
+        carbon_offsets.originaltx,
+    ])
+
+    # carbon_offsets = carbon_data.Query.batchCalls(
+    #     first=MAX_RECORDS
+    # )
+    # df_bridged_calls = sg.query_df([
+    #     carbon_offsets.id,
+    #     carbon_offsets.serialNumber,
+    #     carbon_offsets.timestamp,
+    #     carbon_offsets.tokenAddress,
+    #     carbon_offsets.vintage,
+    #     carbon_offsets.projectID,
+    #     carbon_offsets.value,
+    #     carbon_offsets.originaltx,
+    # ])
+
+    carbon_data = sg.load_subgraph(CARBON_ETH_SUBGRAPH_URL)
+    carbon_offsets = carbon_data.Query.bridges(
+        first=MAX_RECORDS
+    )
+    df_bridged_tx = sg.query_df([
+        carbon_offsets.value,
+        carbon_offsets.timestamp,
+        carbon_offsets.transaction.id,
+    ])
+
+    carbon_data = sg.load_subgraph(CARBON_ETH_SUBGRAPH_URL)
+    carbon_offsets = carbon_data.Query.retires(
+        first=MAX_RECORDS
+    )
+    df_retired = sg.query_df([
+        carbon_offsets.value,
+        carbon_offsets.timestamp,
+        carbon_offsets.offset.tokenAddress,
+        carbon_offsets.offset.bridge,
+        carbon_offsets.offset.region,
+        carbon_offsets.offset.vintage,
+        carbon_offsets.offset.projectID,
+        carbon_offsets.offset.standard,
+        carbon_offsets.offset.methodology,
+        carbon_offsets.offset.standard,
+        carbon_offsets.offset.country,
+        carbon_offsets.offset.category,
+        carbon_offsets.offset.name,
+        carbon_offsets.offset.totalRetired,
+    ])
+    return df_bridged, df_bridged_tx, df_retired
+
+
+@cache.memoize()
 def get_verra_data():
     use_fallback_data = False
     if use_fallback_data:
@@ -193,6 +266,7 @@ def get_verra_data():
 web3 = get_eth_web3() if os.environ.get('WEB3_INFURA_PROJECT_ID') else None
 
 
+@cache.memoize()
 def get_mco2_contract_data():
     ERC20_ABI = load_abi('erc20.json')
     if web3 is not None:
@@ -213,6 +287,7 @@ token_cg_dict = {
 }
 
 
+@cache.memoize()
 def get_prices():
     df_prices = pd.DataFrame()
     for i in token_cg_dict.keys():
@@ -229,14 +304,15 @@ def get_prices():
     return df_prices
 
 
-@cache.memoize()
+# @cache.memoize()
 def generate_layout():
     df, df_retired = get_data()
     df_deposited, df_redeemed = get_data_pool()
     df_pool_retired = get_data_pool_retired()
+    df_bridged_mco2, df_bridged_tx_mco2, df_retired_mco2 = get_mco2_data()
     df_verra, verra_fallback_note = get_verra_data()
-    df_verra, df_verra_toucan = verra_manipulations(df_verra)
-    df_mco2_bridged = read_csv('mco2_verra_data.csv')
+    df_verra, df_verra_toucan, df_verra_c3 = verra_manipulations(df_verra)
+    # df_mco2_bridged = read_csv('mco2_verra_data.csv')
     mco2_current_supply = get_mco2_contract_data()
     df_prices = get_prices()
     curr_time_str = datetime.utcnow().strftime("%m/%d/%Y, %H:%M:%S")
@@ -244,6 +320,7 @@ def generate_layout():
     # rename_columns
     df = df.rename(columns=rename_map)
     df_retired = df_retired.rename(columns=retires_rename_map)
+
     # -----TCO2_Figures----
     # Bridge manipulations
     df_tc = bridge_manipulations(df, "Toucan")
@@ -485,26 +562,47 @@ def generate_layout():
     cache.set("content_c3t", content_c3t)
 
     # --MCO2 Figures--
-    df_mco2_bridged = df_mco2_bridged.rename(columns=mco2_verra_rename_map)
+
+    df_bridged_mco2 = df_bridged_mco2.rename(columns=mco2_bridged_rename_map)
+    df_verra_retired = verra_retired(df_verra, df_bridged_mco2)
+    df_retired_mco2 = df_retired_mco2.rename(columns=retires_rename_map)
+    df_bridged_tx_mco2 = df_bridged_tx_mco2.rename(columns=bridges_rename_map)
+    pd.set_option('display.max_columns', None)
+    pd.set_option('display.max_colwidth', None)
+    df_retired_mco2 = bridge_manipulations(df_retired_mco2, "Moss")
+    df_bridged_mco2["Project ID"] = 'VCS-' + \
+        df_bridged_mco2["Project ID"].astype(str)
+    df_bridged_mco2 = merge_verra(df_bridged_mco2, df_verra, merge_columns+['Vintage Start'], [
+        'Name', 'Country', 'Project Type', 'Vintage'])
+    df_bridged_mco2["Vintage"] = df_bridged_mco2['Serial Number'].astype(
+        str).str[-15:-11].astype(int)
+    df_retired_mco2 = merge_verra(df_retired_mco2, df_verra, merge_columns, [
+        'Name', 'Country', 'Project Type'])
+    df_bridged_mco2 = adjust_mco2_bridges(df_bridged_mco2, df_bridged_tx_mco2)
+    df_bridged_mco2 = date_manipulations_verra(df_bridged_mco2)
+    df_retired_mco2 = date_manipulations(df_retired_mco2)
+    print(df_bridged_mco2)
+    print(df_retired_mco2)
     zero_bridging_evt_text = "There haven't been any<br>bridging events"
-    df_mco2_bridged = df_mco2_bridged.rename(columns=mco2_verra_rename_map)
-    df_mco2_bridged["Project ID"] = 'VCS-' + \
-        df_mco2_bridged["Project ID"].astype(str)
-    df_mco2_bridged = merge_verra(
-        df_mco2_bridged, df_verra, ["ID", "Country", "Methodology"], None)
-    df_mco2_bridged = mco2_verra_manipulations(df_mco2_bridged)
+    # fig_mco2_total_volume = total_volume(
+    #     df_bridged_mco2, "Credits bridged (total)", zero_bridging_evt_text)
+    fig_mco2_total_volume = deposited_over_time(
+        df_bridged_mco2)
     fig_mco2_total_vintage = total_vintage(
-        df_mco2_bridged, zero_bridging_evt_text)
-    fig_mco2_total_map = map(df_mco2_bridged, zero_bridging_evt_text)
+        df_bridged_mco2, zero_bridging_evt_text)
+    fig_mco2_total_map = map(df_bridged_mco2, zero_bridging_evt_text)
     fig_mco2_total_metho = methodology_volume(
-        df_mco2_bridged, zero_bridging_evt_text)
+        df_bridged_mco2, zero_bridging_evt_text)
     fig_mco2_total_project = project_volume(
-        df_mco2_bridged, zero_bridging_evt_text)
-    content_mco2 = create_content_moss(df_mco2_bridged, fig_mco2_total_vintage, fig_mco2_total_map,
-                                       fig_mco2_total_metho, fig_mco2_total_project, mco2_current_supply)
+        df_bridged_mco2, zero_bridging_evt_text)
+    df_bridged_mco2_summary = mco2_verra_manipulations(df_bridged_mco2)
+    content_mco2 = create_content_moss(df_bridged_mco2_summary, df_retired_mco2, fig_mco2_total_volume,
+                                       fig_mco2_total_vintage, fig_mco2_total_map,
+                                       fig_mco2_total_metho, fig_mco2_total_project)
 
     cache.set("content_mco2", content_mco2)
 
+    # Stopped here
     # --Carbon Pool Figures---
 
     # rename_columns
@@ -653,23 +751,64 @@ def generate_layout():
     token_cg_dict['MCO2']['Current Supply'] = mco2_current_supply
 
     bridges_info_dict = {
-        'Toucan': {'Tokenized Quantity': df_verra_toucan["Quantity"].sum(),
-                   'Dataframe': df_verra_toucan},
-        'Moss': {'Tokenized Quantity': df_mco2_bridged["Quantity"].sum(),
-                 'Dataframe': df_mco2_bridged},
-        'C3': {'Tokenized Quantity': df_c3t["Quantity"].sum(),
-               'Dataframe': df_c3t}
+        'Toucan': {'Dataframe': date_manipulations_verra(df_verra_toucan)},
+        'Moss': {'Dataframe': df_bridged_mco2},
+        'C3': {'Dataframe': date_manipulations_verra(df_verra_c3)}
+    }
+
+    retires_info_dict = {
+        'Toucan': {'Dataframe': df_retired_tc},
+        'Moss': {'Dataframe': df_retired_mco2},
+        'C3': {'Dataframe': df_retired_c3t}
     }
     fig_bridges_pie_chart = bridges_pie_chart(bridges_info_dict)
+
+    # ---offchain vs onchain---
+    df_verra["Date"] = df_verra['Issuance Date']
+    df_verra = date_manipulations_verra(df_verra)
+    df_verra_retired = date_manipulations_verra(df_verra_retired)
+
+    # Issued Figures
+    fig_issued_over_time = deposited_over_time(df_verra)
+    fig_tokenized_over_time = tokenized_volume(bridges_info_dict)
     fig_on_vs_off_vintage = on_vs_off_vintage(df_verra, bridges_info_dict)
     fig_on_vs_off_map = on_vs_off_map(df_verra, bridges_info_dict)
     fig_on_vs_off_project = on_vs_off_project(df_verra, bridges_info_dict)
 
-    # ---offchain vs onchain---
+    fig_on_vs_off_issued = [fig_issued_over_time, fig_tokenized_over_time,
+                            fig_on_vs_off_vintage, fig_on_vs_off_map, fig_on_vs_off_project]
+    titles_on_vs_off_issued = ["Cumulative Verra Registry Credits Issued Over Time",
+                               "Cumulative Verra Registry Credits Tokenized Over Time",
+                               "Credits Tokenized vs. Credits Issued by Vintage Start Dates",
+                               "Credits Tokenized vs. Credits Issued by Origin",
+                               "Credits Tokenized vs. Credits Issued by Project Type"]
 
-    content_offchain_vs_onchain = create_offchain_vs_onchain_content(bridges_info_dict, df_verra,
-                                                                     fig_bridges_pie_chart, fig_on_vs_off_vintage,
-                                                                     fig_on_vs_off_map, fig_on_vs_off_project,
+    cache.set("fig_on_vs_off_issued", fig_on_vs_off_issued)
+    cache.set("titles_on_vs_off_issued", titles_on_vs_off_issued)
+
+    # Retired Figures
+    fig_offchain_retired_over_time = deposited_over_time(df_verra_retired)
+    fig_onchain_retired_over_time = tokenized_volume(retires_info_dict)
+    fig_on_vs_off_vintage_retired = on_vs_off_vintage_retired(
+        df_verra_retired, retires_info_dict)
+    fig_on_vs_off_map_retired = on_vs_off_map_retired(
+        df_verra_retired, retires_info_dict)
+    fig_on_vs_off_project_retired = on_vs_off_project_retired(
+        df_verra_retired, retires_info_dict)
+
+    fig_on_vs_off_retired = [fig_offchain_retired_over_time, fig_onchain_retired_over_time,
+                             fig_on_vs_off_vintage_retired, fig_on_vs_off_map_retired, fig_on_vs_off_project_retired]
+    titles_on_vs_off_retired = ["Cumulative Off-Chain Verra Registry Credits Retired Over Time",
+                                "Cumulative On-Chain Verra Registry Credits Retired Over Time",
+                                "Off-Chain vs On-Chain Retired Credits by Vintage Start Dates",
+                                "Off-Chain vs On-Chain Retired Credits by Origin",
+                                "Off-Chain vs On-Chain Retired Credits by Project Type"]
+
+    cache.set("fig_on_vs_off_retired", fig_on_vs_off_retired)
+    cache.set("titles_on_vs_off_retired", titles_on_vs_off_retired)
+
+    content_offchain_vs_onchain = create_offchain_vs_onchain_content(bridges_info_dict, retires_info_dict, df_verra,
+                                                                     df_verra_retired, fig_bridges_pie_chart,
                                                                      verra_fallback_note)
     cache.set("content_offchain_vs_onchain", content_offchain_vs_onchain)
 
@@ -1041,6 +1180,41 @@ def update_output_div_c3(summary_type, C3T_type):
             fig_total_retired = cache.get("fig_total_retired_c3t")
             return "Lifetime Performance", fig_total_retired[0], fig_total_retired[1], fig_total_retired[2],\
                 fig_total_retired[3], fig_total_retired[4]
+
+
+@callback(
+    Output(component_id='offchain-volume-title',
+           component_property='children'),
+    Output(component_id='onchain-volume-title', component_property='children'),
+    Output(component_id='on_vs_off_vintage_title',
+           component_property='children'),
+    Output(component_id="on_vs_off_origin_title",
+           component_property='children'),
+    Output(component_id="on_vs_off_project_title",
+           component_property='children'),
+    Output(component_id='offchain-volume-plot', component_property='figure'),
+    Output(component_id='onchain-volume-plot', component_property='figure'),
+    Output(component_id='on_vs_off_vintage_plot', component_property='figure'),
+    Output(component_id="on_vs_off_origin_plot", component_property='figure'),
+    Output(component_id="on_vs_off_project_plot", component_property='figure'),
+    Input(component_id='issued_or_retired', component_property='value')
+)
+def update_output_on_vs_off(type):
+
+    if type == 'Issued':
+        titles_on_vs_off_issued = cache.get("titles_on_vs_off_issued")
+        fig_on_vs_off_issued = cache.get("fig_on_vs_off_issued")
+        return titles_on_vs_off_issued[0], titles_on_vs_off_issued[1], titles_on_vs_off_issued[2], \
+            titles_on_vs_off_issued[3], titles_on_vs_off_issued[4], \
+            fig_on_vs_off_issued[0], fig_on_vs_off_issued[1], fig_on_vs_off_issued[2], \
+            fig_on_vs_off_issued[3], fig_on_vs_off_issued[4]
+    elif type == 'Retired':
+        titles_on_vs_off_retired = cache.get("titles_on_vs_off_retired")
+        fig_on_vs_off_retired = cache.get("fig_on_vs_off_retired")
+        return titles_on_vs_off_retired[0], titles_on_vs_off_retired[1], \
+            titles_on_vs_off_retired[2], titles_on_vs_off_retired[3], titles_on_vs_off_retired[4], \
+            fig_on_vs_off_retired[0], fig_on_vs_off_retired[1], \
+            fig_on_vs_off_retired[2], fig_on_vs_off_retired[3], fig_on_vs_off_retired[4]
 
 
 @callback(

--- a/src/apps/tco2_dashboard/app.py
+++ b/src/apps/tco2_dashboard/app.py
@@ -1197,6 +1197,12 @@ def update_output_div_c3(summary_type, C3T_type):
     Output(component_id='on_vs_off_vintage_plot', component_property='figure'),
     Output(component_id="on_vs_off_origin_plot", component_property='figure'),
     Output(component_id="on_vs_off_project_plot", component_property='figure'),
+    Output(component_id='on_vs_off_vintage_footer',
+           component_property='children'),
+    Output(component_id='on_vs_off_origin_footer',
+           component_property='children'),
+    Output(component_id='on_vs_off_project_footer',
+           component_property='children'),
     Input(component_id='issued_or_retired', component_property='value')
 )
 def update_output_on_vs_off(type):
@@ -1207,14 +1213,16 @@ def update_output_on_vs_off(type):
         return titles_on_vs_off_issued[0], titles_on_vs_off_issued[1], titles_on_vs_off_issued[2], \
             titles_on_vs_off_issued[3], titles_on_vs_off_issued[4], \
             fig_on_vs_off_issued[0], fig_on_vs_off_issued[1], fig_on_vs_off_issued[2], \
-            fig_on_vs_off_issued[3], fig_on_vs_off_issued[4]
+            fig_on_vs_off_issued[3], fig_on_vs_off_issued[4], None, None, None
     elif type == 'Retired':
+        moss_note = 'Note: Project metadata of Moss Retired VCUs is unavailable'
         titles_on_vs_off_retired = cache.get("titles_on_vs_off_retired")
         fig_on_vs_off_retired = cache.get("fig_on_vs_off_retired")
         return titles_on_vs_off_retired[0], titles_on_vs_off_retired[1], \
             titles_on_vs_off_retired[2], titles_on_vs_off_retired[3], titles_on_vs_off_retired[4], \
             fig_on_vs_off_retired[0], fig_on_vs_off_retired[1], \
-            fig_on_vs_off_retired[2], fig_on_vs_off_retired[3], fig_on_vs_off_retired[4]
+            fig_on_vs_off_retired[2], fig_on_vs_off_retired[3], fig_on_vs_off_retired[4], \
+            moss_note, moss_note, moss_note
 
 
 @callback(

--- a/src/apps/tco2_dashboard/assets/styles.css
+++ b/src/apps/tco2_dashboard/assets/styles.css
@@ -253,6 +253,13 @@ color: white;
   padding: 0px;
 }
 
+.on_vs_off_footers{
+  border: 0px;
+  font-style: italic;
+  font-size: 0.7rem;
+  padding: 0px;
+}
+
 .sidebar {
   position: fixed;
   padding: 1rem 2rem;

--- a/src/apps/tco2_dashboard/constants.py
+++ b/src/apps/tco2_dashboard/constants.py
@@ -31,6 +31,17 @@ rename_map = {
     'carbonOffsets_totalBridged': 'Total Quantity',
 }
 
+mco2_bridged_rename_map = {
+    'batches_id': 'ID',
+    'batches_serialNumber': 'Serial Number',
+    'batches_timestamp': 'Date',
+    'batches_tokenAddress': 'Token Address',
+    'batches_vintage': 'Vintage',
+    'batches_projectID': 'Project ID',
+    'batches_value': 'Quantity',
+    'batches_originaltx': 'Original Tx Address',
+}
+
 retires_rename_map = {
     'retires_value': 'Quantity',
     'retires_timestamp': 'Date',
@@ -46,6 +57,13 @@ retires_rename_map = {
     'retires_offset_tokenAddress': 'Token Address',
     'retires_offset_totalRetired': 'Total Quantity',
 }
+
+bridges_rename_map = {
+    'bridges_value': 'Quantity',
+    'bridges_timestamp': 'Date',
+    'bridges_transaction_id': 'Tx Address',
+}
+
 
 redeems_rename_map = {
     'redeems_value': 'Quantity',

--- a/src/apps/tco2_dashboard/figures.py
+++ b/src/apps/tco2_dashboard/figures.py
@@ -575,7 +575,6 @@ def on_vs_off_vintage_retired(df_verra_retired, retires_info_dict):
     df_verra_retired = df_verra_retired[df_verra_retired["Vintage"] != "missing"]
     df_verra_grouped = df_verra_retired.groupby(
         'Vintage')['Quantity'].sum().to_frame().reset_index()
-    # df_verra_other_grouped = pd.DataFrame()
     dfs = []
     for i in retires_info_dict.keys():
         df = retires_info_dict[i]["Dataframe"]
@@ -584,18 +583,6 @@ def on_vs_off_vintage_retired(df_verra_retired, retires_info_dict):
             'Vintage')['Quantity'].sum().to_frame().reset_index()
         df['Type'] = f'{i} Retired VCUs'
         dfs.append(df)
-        # if df_verra_other_grouped.empty:
-        #     df_verra_other_grouped = df_verra_grouped.merge(df, how='left', left_on="Vintage",
-        #                                                     right_on='Vintage', suffixes=('', f"_{i}"))
-        # else:
-        #     df_verra_other_grouped = df_verra_other_grouped.merge(df, how='left', left_on="Vintage",
-        #                                                           right_on='Vintage', suffixes=('', f"_{i}"))
-        # df_verra_other_grouped[f'Quantity_{i}'] = df_verra_other_grouped[f'Quantity_{i}'].fillna(
-        #     0)
-        # df_verra_other_grouped['Quantity'] = df_verra_other_grouped['Quantity'] - \
-        #     df_verra_other_grouped[f'Quantity_{i}']
-        # df_verra_other_grouped = df_verra_other_grouped[[
-        #     'Vintage', 'Quantity']]
     df_verra_grouped['Type'] = 'Off-Chain Retired VCUs'
 
     df_other_and_bridges = pd.concat(
@@ -799,7 +786,6 @@ def on_vs_off_project_retired(df_verra_retired, retires_info_dict):
     df_verra_retired = df_verra_retired[df_verra_retired["Project Type"] != "missing"]
     df_verra_grouped = df_verra_retired.groupby(
         'Project Type')['Quantity'].sum().to_frame().reset_index()
-    # df_verra_other_grouped = pd.DataFrame()
     colors = {}
     dfs = []
     for i in retires_info_dict.keys():
@@ -810,18 +796,6 @@ def on_vs_off_project_retired(df_verra_retired, retires_info_dict):
         df['Type'] = f'{i} Retired VCUs'
         colors[f'{i} Retired VCUs'] = '#00CC33'
         dfs.append(df)
-        # if df_verra_other_grouped.empty:
-        #     df_verra_other_grouped = df_verra_grouped.merge(df, how='left', left_on="Project Type",
-        #                                                     right_on='Project Type', suffixes=('', f"_{i}"))
-        # else:
-        #     df_verra_other_grouped = df_verra_other_grouped.merge(df, how='left', left_on="Project Type",
-        #                                                           right_on='Project Type', suffixes=('', f"_{i}"))
-        # df_verra_other_grouped[f'Quantity_{i}'] = df_verra_other_grouped[f'Quantity_{i}'].fillna(
-        #     0)
-        # df_verra_other_grouped['Quantity'] = df_verra_other_grouped['Quantity'] - \
-        #     df_verra_other_grouped[f'Quantity_{i}']
-        # df_verra_other_grouped = df_verra_other_grouped[[
-        #     'Project Type', 'Quantity']]
     df_verra_grouped['Type'] = 'Off-Chain Retired VCUs'
     colors['Off-Chain Retired VCUs'] = '#536C9C'
     colors['(?)'] = '#6E6E6E'

--- a/src/apps/tco2_dashboard/figures.py
+++ b/src/apps/tco2_dashboard/figures.py
@@ -596,7 +596,7 @@ def on_vs_off_vintage_retired(df_verra_retired, retires_info_dict):
         #     df_verra_other_grouped[f'Quantity_{i}']
         # df_verra_other_grouped = df_verra_other_grouped[[
         #     'Vintage', 'Quantity']]
-    df_verra_grouped['Type'] = 'Offchain Retired VCUs'
+    df_verra_grouped['Type'] = 'Off-Chain Retired VCUs'
 
     df_other_and_bridges = pd.concat(
         dfs + [df_verra_grouped]).reset_index()
@@ -742,7 +742,7 @@ def on_vs_off_map_retired(df_verra_retired, retires_info_dict):
                       hoverlabel=dict(font_color='white', font_size=8), font_size=8,
                       margin=dict(t=20, b=20, l=0, r=0),
                       legend=dict(font=dict(size=8), tracegroupgap=0,
-                      title=" Percentage On-Chain <br> Retired Credits", y=0.5))
+                      title=" Percentage On-Chain <br>    Retired Credits", y=0.5))
     return fig
 
 
@@ -752,12 +752,14 @@ def on_vs_off_project(df_verra, bridges_info_dict):
         'Project Type')['Quantity'].sum().to_frame().reset_index()
     df_verra_other_grouped = pd.DataFrame()
     dfs = []
+    colors = {}
     for i in bridges_info_dict.keys():
         df = bridges_info_dict[i]["Dataframe"]
         df = df[df["Project Type"] != "missing"]
         df = df.groupby(
             'Project Type')['Quantity'].sum().to_frame().reset_index()
         df['Type'] = f'{i} Bridged VCUs'
+        colors[f'{i} Bridged VCUs'] = '#00CC33'
         dfs.append(df)
         if df_verra_other_grouped.empty:
             df_verra_other_grouped = df_verra_grouped.merge(df, how='left', left_on="Project Type",
@@ -772,12 +774,15 @@ def on_vs_off_project(df_verra, bridges_info_dict):
         df_verra_other_grouped = df_verra_other_grouped[[
             'Project Type', 'Quantity']]
         df_verra_other_grouped['Type'] = 'Rest of Issued VCUs'
-
+    colors['Rest of Issued VCUs'] = '#536C9C'
+    colors['(?)'] = '#6E6E6E'
     df_other_and_bridges = pd.concat(
         dfs + [df_verra_other_grouped]).reset_index()
     fig = px.treemap(df_other_and_bridges, path=[px.Constant("All Projects"), 'Project Type', 'Type'],
                      values='Quantity',
-                     color_discrete_sequence=px.colors.qualitative.Antique,
+                     color_discrete_map=colors,
+                     #  color_discrete_sequence=px.colors.qualitative.Antique,
+                     color='Type',
                      hover_data=['Type', 'Quantity'],
                      height=480, title='')
     fig.update_traces(textfont=dict(color='white'), textinfo="label+value+percent parent+percent entry+percent root",
@@ -795,6 +800,7 @@ def on_vs_off_project_retired(df_verra_retired, retires_info_dict):
     df_verra_grouped = df_verra_retired.groupby(
         'Project Type')['Quantity'].sum().to_frame().reset_index()
     # df_verra_other_grouped = pd.DataFrame()
+    colors = {}
     dfs = []
     for i in retires_info_dict.keys():
         df = retires_info_dict[i]["Dataframe"]
@@ -802,6 +808,7 @@ def on_vs_off_project_retired(df_verra_retired, retires_info_dict):
         df = df.groupby(
             'Project Type')['Quantity'].sum().to_frame().reset_index()
         df['Type'] = f'{i} Retired VCUs'
+        colors[f'{i} Retired VCUs'] = '#00CC33'
         dfs.append(df)
         # if df_verra_other_grouped.empty:
         #     df_verra_other_grouped = df_verra_grouped.merge(df, how='left', left_on="Project Type",
@@ -816,12 +823,15 @@ def on_vs_off_project_retired(df_verra_retired, retires_info_dict):
         # df_verra_other_grouped = df_verra_other_grouped[[
         #     'Project Type', 'Quantity']]
     df_verra_grouped['Type'] = 'Off-Chain Retired VCUs'
-
+    colors['Off-Chain Retired VCUs'] = '#536C9C'
+    colors['(?)'] = '#6E6E6E'
     df_other_and_bridges = pd.concat(
         dfs + [df_verra_grouped]).reset_index()
     fig = px.treemap(df_other_and_bridges, path=[px.Constant("All Projects"), 'Project Type', 'Type'],
                      values='Quantity',
-                     color_discrete_sequence=px.colors.qualitative.Antique,
+                     color_discrete_map=colors,
+                     #  color_discrete_sequence=px.colors.qualitative.Antique,
+                     color='Type',
                      hover_data=['Type', 'Quantity'],
                      height=480, title='')
     fig.update_traces(textfont=dict(color='white'), textinfo="label+value+percent parent+percent entry+percent root",

--- a/src/apps/tco2_dashboard/figures.py
+++ b/src/apps/tco2_dashboard/figures.py
@@ -326,7 +326,8 @@ def pool_pie_chart(df, labels):
 
 def bridges_pie_chart(bridges_info_dict):
     labels = list(bridges_info_dict.keys())
-    values = [d['Tokenized Quantity'] for d in bridges_info_dict.values()]
+    values = [d['Dataframe']["Quantity"].sum()
+              for d in bridges_info_dict.values()]
     fig = go.Figure()
     fig.add_trace(go.Pie(labels=labels, values=values,  textinfo='percent', textfont=dict(
         color='white', size=12), hoverlabel=dict(font_color='white', font_size=12), hole=.3))
@@ -485,7 +486,8 @@ def pool_retired_chart(token_cg_dict, df_pool_retired):
         pool_address = token_cg_dict[i]['address']
         filtered_df = df_pool_retired
         filtered_df[f'Quantity_{i}'] = filtered_df['Quantity']
-        filtered_df.loc[filtered_df['Pool'] != pool_address, f'Quantity_{i}'] = 0
+        filtered_df.loc[filtered_df['Pool'] !=
+                        pool_address, f'Quantity_{i}'] = 0
         filtered_df = filtered_df.sort_values(by="Date", ascending=True)
         filtered_df[f'Quantity_{i}'] = filtered_df[f'Quantity_{i}'].cumsum()
         fig.add_trace(go.Scatter(x=filtered_df['Date'], y=filtered_df[f'Quantity_{i}'],
@@ -503,7 +505,30 @@ def pool_retired_chart(token_cg_dict, df_pool_retired):
     return fig
 
 
+def tokenized_volume(bridges_info_dict):
+    fig = go.Figure()
+    for i in bridges_info_dict.keys():
+        df = bridges_info_dict[i]["Dataframe"]
+        df = df.sort_values(by="Date", ascending=True)
+        df["Quantity"] = df["Quantity"].cumsum()
+        df['Type'] = f'{i} Bridged Credits'
+        fig.add_trace(go.Scatter(x=df['Date'], y=df['Quantity'],
+                                 mode='lines',
+                                 name=i,
+                                 stackgroup='one'
+                                 )
+                      )
+        fig.update_layout(height=300, font=dict(color='white'),
+                          xaxis_title='Date', yaxis_title='Quantity',
+                          paper_bgcolor=FIGURE_BG_COLOR, plot_bgcolor=FIGURE_BG_COLOR, xaxis=dict(
+                          showgrid=False), yaxis=dict(showgrid=False),
+                          margin=dict(t=20, b=20, l=0, r=0),
+                          hovermode='x unified', hoverlabel=dict(font_color='white', font_size=8))
+    return fig
+
+
 def on_vs_off_vintage(df_verra, bridges_info_dict):
+    df_verra = df_verra[df_verra["Vintage"] != "missing"]
     df_verra_grouped = df_verra.groupby(
         'Vintage')['Quantity'].sum().to_frame().reset_index()
     df_verra_other_grouped = pd.DataFrame()
@@ -513,7 +538,7 @@ def on_vs_off_vintage(df_verra, bridges_info_dict):
         df = df[df["Vintage"] != "missing"]
         df = df.groupby(
             'Vintage')['Quantity'].sum().to_frame().reset_index()
-        df['Type'] = f'{i} Bridged Credits'
+        df['Type'] = f'{i} Bridged VCUs'
         dfs.append(df)
         if df_verra_other_grouped.empty:
             df_verra_other_grouped = df_verra_grouped.merge(df, how='left', left_on="Vintage",
@@ -527,7 +552,7 @@ def on_vs_off_vintage(df_verra, bridges_info_dict):
             df_verra_other_grouped[f'Quantity_{i}']
         df_verra_other_grouped = df_verra_other_grouped[[
             'Vintage', 'Quantity']]
-        df_verra_other_grouped['Type'] = 'Rest of Issued VCU'
+        df_verra_other_grouped['Type'] = 'Rest of Issued VCUs'
 
     df_other_and_bridges = pd.concat(
         dfs + [df_verra_other_grouped]).reset_index()
@@ -546,7 +571,52 @@ def on_vs_off_vintage(df_verra, bridges_info_dict):
     return fig
 
 
+def on_vs_off_vintage_retired(df_verra_retired, retires_info_dict):
+    df_verra_retired = df_verra_retired[df_verra_retired["Vintage"] != "missing"]
+    df_verra_grouped = df_verra_retired.groupby(
+        'Vintage')['Quantity'].sum().to_frame().reset_index()
+    # df_verra_other_grouped = pd.DataFrame()
+    dfs = []
+    for i in retires_info_dict.keys():
+        df = retires_info_dict[i]["Dataframe"]
+        df = df[df["Vintage"] != "missing"]
+        df = df.groupby(
+            'Vintage')['Quantity'].sum().to_frame().reset_index()
+        df['Type'] = f'{i} Retired VCUs'
+        dfs.append(df)
+        # if df_verra_other_grouped.empty:
+        #     df_verra_other_grouped = df_verra_grouped.merge(df, how='left', left_on="Vintage",
+        #                                                     right_on='Vintage', suffixes=('', f"_{i}"))
+        # else:
+        #     df_verra_other_grouped = df_verra_other_grouped.merge(df, how='left', left_on="Vintage",
+        #                                                           right_on='Vintage', suffixes=('', f"_{i}"))
+        # df_verra_other_grouped[f'Quantity_{i}'] = df_verra_other_grouped[f'Quantity_{i}'].fillna(
+        #     0)
+        # df_verra_other_grouped['Quantity'] = df_verra_other_grouped['Quantity'] - \
+        #     df_verra_other_grouped[f'Quantity_{i}']
+        # df_verra_other_grouped = df_verra_other_grouped[[
+        #     'Vintage', 'Quantity']]
+    df_verra_grouped['Type'] = 'Offchain Retired VCUs'
+
+    df_other_and_bridges = pd.concat(
+        dfs + [df_verra_grouped]).reset_index()
+    fig = px.bar(df_other_and_bridges, x="Vintage",
+                 y="Quantity", color="Type", title="", height=300)
+    fig.update_traces(marker_line_width=0)
+    fig.update_layout(height=360, paper_bgcolor=FIGURE_BG_COLOR, plot_bgcolor=FIGURE_BG_COLOR,
+                      xaxis=dict(showgrid=False),
+                      yaxis=dict(showgrid=False), font_color='white', hovermode='x unified',
+                      hoverlabel=dict(font_color='white', font_size=8), font_size=8,
+                      legend=dict(title="", orientation="h", yanchor="bottom",
+                                  y=1.02, xanchor="right", x=1
+                                  ),
+                      margin=dict(t=80, b=20, l=0, r=0))
+
+    return fig
+
+
 def on_vs_off_map(df_verra, bridges_info_dict):
+    df_verra = df_verra[df_verra["Country"] != "missing"]
     df_verra_grouped = df_verra.groupby(
         'Country')['Quantity'].sum().to_frame().reset_index()
     df_verra_grouped["Text_Bridges"] = ""
@@ -556,7 +626,7 @@ def on_vs_off_map(df_verra, bridges_info_dict):
         df = df[df["Country"] != "missing"]
         df = df.groupby(
             'Country')['Quantity'].sum().to_frame().reset_index()
-        df['Type'] = f'{i} Bridged Credit'
+        df['Type'] = f'{i} Bridged VCUs'
         df_verra_grouped = df_verra_grouped.merge(df, how='left', left_on="Country",
                                                   right_on='Country', suffixes=('', f"_{i}"))
         df_verra_grouped[f'Quantity_{i}'] = df_verra_grouped[f'Quantity_{i}'].fillna(
@@ -564,14 +634,14 @@ def on_vs_off_map(df_verra, bridges_info_dict):
         df_verra_grouped["Quantity_Bridges"] = df_verra_grouped["Quantity_Bridges"] + \
             df_verra_grouped[f'Quantity_{i}']
         df_verra_grouped["Text_Bridges"] = df_verra_grouped["Text_Bridges"] + \
-            f'{i} Bridged Credits = ' + \
+            f'{i} Bridged VCUs = ' + \
             df_verra_grouped[f'Quantity_{i}'].map(
                 '{:,.0f}'.format).astype(str) + '<br>'
     df_verra_grouped["Percentage"] = ((df_verra_grouped["Quantity_Bridges"] /
                                        df_verra_grouped['Quantity'])*100).round(decimals=4)
     df_verra_grouped['text'] = df_verra_grouped['Country'] + '<br>' + '<br>' + \
         df_verra_grouped["Text_Bridges"] + \
-        'Total Tokenized Credits = ' + df_verra_grouped['Quantity_Bridges'].map('{:,.0f}'.format).astype(str) + \
+        'Total Tokenized VCUs = ' + df_verra_grouped['Quantity_Bridges'].map('{:,.0f}'.format).astype(str) + \
         '<br>' +\
         'Verra Issued Credits = ' + df_verra_grouped['Quantity'].map('{:,.0f}'.format).astype(str) + '<br>' +\
         'Percentage = ' + \
@@ -610,7 +680,74 @@ def on_vs_off_map(df_verra, bridges_info_dict):
     return fig
 
 
+def on_vs_off_map_retired(df_verra_retired, retires_info_dict):
+    df_verra_retired = df_verra_retired[df_verra_retired["Country"] != "missing"]
+    df_verra_grouped = df_verra_retired.groupby(
+        'Country')['Quantity'].sum().to_frame().reset_index()
+    df_verra_grouped["Text_Retires"] = ""
+    df_verra_grouped["Quantity_Retires"] = 0
+    for i in retires_info_dict.keys():
+        df = retires_info_dict[i]["Dataframe"]
+        df = df[df["Country"] != "missing"]
+        df = df.groupby(
+            'Country')['Quantity'].sum().to_frame().reset_index()
+        df['Type'] = f'{i} Retired VCUs'
+        df_verra_grouped = df_verra_grouped.merge(df, how='left', left_on="Country",
+                                                  right_on='Country', suffixes=('', f"_{i}"))
+        df_verra_grouped[f'Quantity_{i}'] = df_verra_grouped[f'Quantity_{i}'].fillna(
+            0)
+        df_verra_grouped["Quantity_Retires"] = df_verra_grouped["Quantity_Retires"] + \
+            df_verra_grouped[f'Quantity_{i}']
+        df_verra_grouped["Text_Retires"] = df_verra_grouped["Text_Retires"] + \
+            f'{i} Retired VCUs = ' + \
+            df_verra_grouped[f'Quantity_{i}'].map(
+                '{:,.0f}'.format).astype(str) + '<br>'
+    df_verra_grouped["Percentage"] = ((df_verra_grouped["Quantity_Retires"] /
+                                       (df_verra_grouped["Quantity_Retires"] +
+                                           df_verra_grouped['Quantity']))*100).round(decimals=4)
+    df_verra_grouped['text'] = df_verra_grouped['Country'] + '<br>' + '<br>' + \
+        df_verra_grouped["Text_Retires"] + \
+        'Total On-Chain Retired VCUs = ' + df_verra_grouped['Quantity_Retires'].map('{:,.0f}'.format).astype(str) + \
+        '<br>' +\
+        'Total Verra Retired Credits = ' + df_verra_grouped['Quantity'].map('{:,.0f}'.format).astype(str) + '<br>' +\
+        'Percentage = ' + \
+        df_verra_grouped['Percentage'].astype(str) + '%' + '<br>'
+    df_verra_grouped = df_verra_grouped[df_verra_grouped["Country"] != ""].reset_index(
+        drop=True)
+    country_index = defaultdict(str, {country: pycountry.countries.search_fuzzy(country)[
+                                0].alpha_3 for country in df_verra_grouped.Country.astype(str).unique()
+        if country != 'nan'})
+    df_verra_grouped['Country Code'] = [country_index[country]
+                                        for country in df_verra_grouped['Country']]
+
+    cut_bins = [-np.inf, 0, 2, 5, 10, 100]
+    bin_labels = ["0", "(0-2]", "(2-5]", "(5-10]", "(10-100]"]
+    df_verra_grouped["Percentage Bins"] = pd.cut(
+        df_verra_grouped["Percentage"], bins=cut_bins, labels=bin_labels)
+    df_verra_grouped = df_verra_grouped.sort_values(by=["Percentage"])
+
+    fig = px.choropleth(df_verra_grouped, locations="Country Code",
+                        color="Percentage Bins",
+                        hover_name='Country',
+                        custom_data=['text'],
+                        color_discrete_sequence=px.colors.sequential.Plasma_r,
+                        height=300)
+
+    fig.update_traces(hovertemplate="%{customdata}")
+
+    fig.update_layout(height=360, geo=dict(bgcolor='rgba(0,0,0,0)', lakecolor='#4E5D6C',
+                                           landcolor='darkgrey',
+                                           subunitcolor='grey'),
+                      font_color='white', dragmode=False, paper_bgcolor=FIGURE_BG_COLOR,  hovermode='x unified',
+                      hoverlabel=dict(font_color='white', font_size=8), font_size=8,
+                      margin=dict(t=20, b=20, l=0, r=0),
+                      legend=dict(font=dict(size=8), tracegroupgap=0,
+                      title=" Percentage On-Chain <br> Retired Credits", y=0.5))
+    return fig
+
+
 def on_vs_off_project(df_verra, bridges_info_dict):
+    df_verra = df_verra[df_verra["Project Type"] != "missing"]
     df_verra_grouped = df_verra.groupby(
         'Project Type')['Quantity'].sum().to_frame().reset_index()
     df_verra_other_grouped = pd.DataFrame()
@@ -620,7 +757,7 @@ def on_vs_off_project(df_verra, bridges_info_dict):
         df = df[df["Project Type"] != "missing"]
         df = df.groupby(
             'Project Type')['Quantity'].sum().to_frame().reset_index()
-        df['Type'] = f'{i} Bridged Credits'
+        df['Type'] = f'{i} Bridged VCUs'
         dfs.append(df)
         if df_verra_other_grouped.empty:
             df_verra_other_grouped = df_verra_grouped.merge(df, how='left', left_on="Project Type",
@@ -634,10 +771,54 @@ def on_vs_off_project(df_verra, bridges_info_dict):
             df_verra_other_grouped[f'Quantity_{i}']
         df_verra_other_grouped = df_verra_other_grouped[[
             'Project Type', 'Quantity']]
-        df_verra_other_grouped['Type'] = 'Rest of Issued VCU'
+        df_verra_other_grouped['Type'] = 'Rest of Issued VCUs'
 
     df_other_and_bridges = pd.concat(
         dfs + [df_verra_other_grouped]).reset_index()
+    fig = px.treemap(df_other_and_bridges, path=[px.Constant("All Projects"), 'Project Type', 'Type'],
+                     values='Quantity',
+                     color_discrete_sequence=px.colors.qualitative.Antique,
+                     hover_data=['Type', 'Quantity'],
+                     height=480, title='')
+    fig.update_traces(textfont=dict(color='white'), textinfo="label+value+percent parent+percent entry+percent root",
+                      texttemplate='<br>'.join(['%{label}', 'Quantity=%{value}', '%{percentParent} of Parent',
+                                                '%{percentEntry} of Entry', '%{percentRoot} of Root']))
+    fig.update_layout(paper_bgcolor=FIGURE_BG_COLOR, plot_bgcolor=FIGURE_BG_COLOR, font=dict(color='white'),
+                      hoverlabel=dict(font_color='white', font_size=8), font_size=12,
+                      margin=dict(t=20, b=20, l=0, r=0))
+
+    return fig
+
+
+def on_vs_off_project_retired(df_verra_retired, retires_info_dict):
+    df_verra_retired = df_verra_retired[df_verra_retired["Project Type"] != "missing"]
+    df_verra_grouped = df_verra_retired.groupby(
+        'Project Type')['Quantity'].sum().to_frame().reset_index()
+    # df_verra_other_grouped = pd.DataFrame()
+    dfs = []
+    for i in retires_info_dict.keys():
+        df = retires_info_dict[i]["Dataframe"]
+        df = df[df["Project Type"] != "missing"]
+        df = df.groupby(
+            'Project Type')['Quantity'].sum().to_frame().reset_index()
+        df['Type'] = f'{i} Retired VCUs'
+        dfs.append(df)
+        # if df_verra_other_grouped.empty:
+        #     df_verra_other_grouped = df_verra_grouped.merge(df, how='left', left_on="Project Type",
+        #                                                     right_on='Project Type', suffixes=('', f"_{i}"))
+        # else:
+        #     df_verra_other_grouped = df_verra_other_grouped.merge(df, how='left', left_on="Project Type",
+        #                                                           right_on='Project Type', suffixes=('', f"_{i}"))
+        # df_verra_other_grouped[f'Quantity_{i}'] = df_verra_other_grouped[f'Quantity_{i}'].fillna(
+        #     0)
+        # df_verra_other_grouped['Quantity'] = df_verra_other_grouped['Quantity'] - \
+        #     df_verra_other_grouped[f'Quantity_{i}']
+        # df_verra_other_grouped = df_verra_other_grouped[[
+        #     'Project Type', 'Quantity']]
+    df_verra_grouped['Type'] = 'Off-Chain Retired VCUs'
+
+    df_other_and_bridges = pd.concat(
+        dfs + [df_verra_grouped]).reset_index()
     fig = px.treemap(df_other_and_bridges, path=[px.Constant("All Projects"), 'Project Type', 'Type'],
                      values='Quantity',
                      color_discrete_sequence=px.colors.qualitative.Antique,

--- a/src/apps/tco2_dashboard/helpers.py
+++ b/src/apps/tco2_dashboard/helpers.py
@@ -54,6 +54,28 @@ def date_manipulations(df):
     return df
 
 
+def date_manipulations_verra(df):
+    if not(df.empty):
+        df["Date"] = pd.to_datetime(df["Date"], unit='s').dt.tz_localize(
+            None).dt.floor('D').dt.date
+        datelist = pd.date_range(start=df["Date"].min()+pd.DateOffset(-1),
+                                 end=pd.to_datetime('today'), freq='d')
+        df_date = pd.DataFrame()
+        df_date["Date_continous"] = datelist
+        df_date["Date_continous"] = pd.to_datetime(df_date["Date_continous"],  unit='s').dt.tz_localize(
+            None).dt.floor('D').dt.date
+        df = df.merge(df_date, how='right', left_on='Date',
+                      right_on='Date_continous').reset_index(drop=True)
+        df["Date"] = df["Date_continous"]
+        for i in df.columns:
+            if "Quantity" in i:
+                df[i] = df[i].fillna(0)
+            else:
+                df[i] = df[i].fillna("missing")
+                df[i] = df[i].replace("", "missing")
+    return df
+
+
 def black_list_manipulations(df):
     # Dropping rows where Region = "", these tokenized carbon credits are black-listed
     # Black listed because their methodology = "AM0001"
@@ -73,12 +95,23 @@ def merge_verra(df, df_verra, merge_columns, drop_columns):
     df_verra = df_verra[merge_columns]
     df_verra = df_verra.drop_duplicates(
         subset=['ID']).reset_index(drop=True)
-    if drop_columns:
-        df = df.drop(columns=drop_columns)
+    for i in drop_columns:
+        if i in df.columns:
+            df = df.drop(columns=i)
     df = df.merge(df_verra, how='left', left_on="Project ID Key",
                   right_on='ID', suffixes=('', '_Verra'))
 
     return df
+
+# def merge_verra_mco2(df, df_verra, merge_columns, drop_columns):
+#     # df["Project ID Key"] = df["Project ID"].astype(str).str[4:]
+#     df_verra = df_verra[merge_columns]
+#     for i in drop_columns:
+#         if i in df.columns:
+#             df = df.drop(columns=i)
+#     df = df.merge(df_verra, how='left', left_on="Serial Number",
+#                   right_on='Serial Number', suffixes=('', '_Verra'))
+#     return df
 
 
 def region_manipulations(df):
@@ -120,21 +153,47 @@ def filter_df_by_pool(df, pool_address):
 
 
 def verra_manipulations(df_verra):
+    df_verra['Vintage'] = df_verra['Vintage Start']
     df_verra['Vintage'] = pd.to_datetime(
         df_verra["Vintage Start"]).dt.tz_localize(None).dt.year
     df_verra['Quantity'] = df_verra['Quantity Issued']
+    df_verra['Retirement/Cancellation Date'] = pd.to_datetime(
+        df_verra['Retirement/Cancellation Date'])
+    df_verra['Date'] = df_verra['Retirement/Cancellation Date']
     df_verra.loc[df_verra['Retirement Details'].str.contains(
         'TOUCAN').fillna(False), 'Toucan'] = True
     df_verra['Toucan'] = df_verra['Toucan'].fillna(False)
+    df_verra.loc[df_verra['Retirement Details'].str.contains(
+        'C3T').fillna(False), 'C3'] = True
+    df_verra['C3'] = df_verra['C3'].fillna(False)
+    df_verra_c3 = df_verra.query('C3')
     df_verra_toucan = df_verra.query('Toucan')
-    return df_verra, df_verra_toucan
+    return df_verra, df_verra_toucan, df_verra_c3
+
+
+def verra_retired(df_verra, df_bridged_mco2):
+    df_verra['Issuance Date'] = pd.to_datetime(df_verra['Issuance Date'])
+    df_verra['Retirement/Cancellation Date'] = pd.to_datetime(
+        df_verra['Retirement/Cancellation Date'])
+    df_verra['Days to Retirement'] = (
+        df_verra['Retirement/Cancellation Date'] - df_verra['Issuance Date']).dt.days
+    df_verra.loc[df_verra['Days to Retirement'] > 0, 'Status'] = 'Retired'
+    df_verra['Status'] = df_verra['Status'].fillna('Available')
+    lst_sn = list(df_bridged_mco2['Serial Number'])
+    df_verra.loc[df_verra['Serial Number'].isin(lst_sn), 'Moss'] = True
+    df_verra['Moss'] = df_verra['Moss'].fillna(False)
+    df_verra_retired = df_verra.query('~Toucan & ~C3 & ~Moss')
+    df_verra_retired = df_verra_retired[df_verra_retired['Status'] == 'Retired']
+    df_verra_retired = df_verra_retired.reset_index(drop=True)
+    return df_verra_retired
 
 
 def mco2_verra_manipulations(df_mco2_bridged):
-    df_mco2_bridged = df_mco2_bridged[[
-        "Project ID", "Vintage", "Quantity", "Country", "Methodology", "Project Type", "Name"]]
-    df_mco2_bridged["Vintage"] = pd.to_datetime(
-        df_mco2_bridged["Vintage"].str[6:10]).dt.tz_localize(None).dt.year
+    df_mco2_bridged = df_mco2_bridged[df_mco2_bridged['Project ID'] != 'missing']
+    # df_mco2_bridged = df_mco2_bridged[[
+    #     "Project ID", "Vintage", "Quantity", "Country", "Methodology", "Project Type", "Name"]]
+    # df_mco2_bridged["Vintage"] = pd.to_datetime(
+    #     df_mco2_bridged["Vintage"].astype(str)).dt.tz_localize(None).dt.year
     df_mco2_bridged["Quantity"] = df_mco2_bridged["Quantity"].astype(int)
     pat = r'VCS-(?P<id>\d+)'
     repl = (
@@ -208,3 +267,14 @@ def read_from_json(filename):
         data = json.load(json_file)
         data = json.loads(data)
     return data
+
+
+def adjust_mco2_bridges(df, df_tx):
+    df_tx = df_tx[['Date', 'Tx Address']]
+    df = df.merge(df_tx, how='left', left_on='Original Tx Address',
+                  right_on='Tx Address', suffixes=('', '_new')).reset_index(drop=True)
+    df.loc[df["Original Tx Address"] != '0x0000000000000000000000000000000000000000000000000000000000000000', 'Date'] \
+        = df.loc[df["Original Tx Address"] !=
+                 '0x0000000000000000000000000000000000000000000000000000000000000000', 'Date_new']
+    df = df.drop(columns=['Tx Address', 'Date_new'])
+    return df

--- a/src/apps/tco2_dashboard/helpers.py
+++ b/src/apps/tco2_dashboard/helpers.py
@@ -190,10 +190,6 @@ def verra_retired(df_verra, df_bridged_mco2):
 
 def mco2_verra_manipulations(df_mco2_bridged):
     df_mco2_bridged = df_mco2_bridged[df_mco2_bridged['Project ID'] != 'missing']
-    # df_mco2_bridged = df_mco2_bridged[[
-    #     "Project ID", "Vintage", "Quantity", "Country", "Methodology", "Project Type", "Name"]]
-    # df_mco2_bridged["Vintage"] = pd.to_datetime(
-    #     df_mco2_bridged["Vintage"].astype(str)).dt.tz_localize(None).dt.year
     df_mco2_bridged["Quantity"] = df_mco2_bridged["Quantity"].astype(int)
     pat = r'VCS-(?P<id>\d+)'
     repl = (

--- a/src/apps/tco2_dashboard/mco2.py
+++ b/src/apps/tco2_dashboard/mco2.py
@@ -4,8 +4,11 @@ import dash_bootstrap_components as dbc
 from .constants import GRAY, DARK_GRAY
 
 
-def create_content_moss(df_mco2_bridged, fig_mco2_total_vintage, fig_mco2_total_map, fig_mco2_total_metho,
-                        fig_mco2_total_project, current_supply):
+def create_content_moss(df_mco2_bridged, df_mco2_retired, fig_mco2_total_volume, fig_mco2_total_vintage,
+                        fig_mco2_total_map, fig_mco2_total_metho,
+                        fig_mco2_total_project):
+    df_mco2_bridged = df_mco2_bridged[[
+        'Project ID', 'Vintage', 'Quantity', 'Country', 'Name', 'Project Type', 'Methodology']]
     df_grouped = df_mco2_bridged.groupby(['Project ID', 'Country', 'Methodology', 'Project Type', 'Name', 'Vintage'])[
         'Quantity'].sum().to_frame().reset_index()
     content_mco2 = [
@@ -26,13 +29,13 @@ def create_content_moss(df_mco2_bridged, fig_mco2_total_vintage, fig_mco2_total_
             dbc.Col(dbc.Card([
                 html.H5("MCO2 Tonnes Retired", className="card-title"),
                 dbc.CardBody("{:,}".format(
-                    int(df_mco2_bridged["Quantity"].sum() - current_supply)), className="card-text")
+                    int(df_mco2_retired["Quantity"].sum())), className="card-text")
             ]), lg=4, md=12),
             dbc.Col(dbc.Card([
                 html.H5("MCO2 Tonnes Outstanding",
                         className="card-title"),
                 dbc.CardBody("{:,}".format(
-                    int(current_supply)), className="card-text")
+                    int(df_mco2_bridged["Quantity"].sum() - df_mco2_retired["Quantity"].sum())), className="card-text")
             ]), lg=4, md=12),
         ], style={'paddingTop': '60px'}),
 
@@ -44,6 +47,16 @@ def create_content_moss(df_mco2_bridged, fig_mco2_total_vintage, fig_mco2_total_
             ]), lg=6, md=12),
             dbc.Col(),
         ], style={'paddingTop': '60px'}),
+
+        dbc.Row([
+            dbc.Col(),
+            dbc.Col(dbc.Card([
+                html.H5("Cumulative Tonnes Bridged Over Time",
+                        className="card-title"),
+                dcc.Graph(figure=fig_mco2_total_volume)
+            ]), width=12),
+            dbc.Col(),
+        ]),
 
         dbc.Row([
             dbc.Col(),

--- a/src/apps/tco2_dashboard/offchain_vs_onchain.py
+++ b/src/apps/tco2_dashboard/offchain_vs_onchain.py
@@ -3,9 +3,8 @@ from dash import dcc
 import dash_bootstrap_components as dbc
 
 
-def create_offchain_vs_onchain_content(bridges_info_dict, df_verra,
-                                       fig_bridges_pie_chart, fig_on_vs_off_vintage,
-                                       fig_on_vs_off_map, fig_on_vs_off_project, verra_fallback_note):
+def create_offchain_vs_onchain_content(bridges_info_dict, retires_info_dict, df_verra, df_verra_retired,
+                                       fig_bridges_pie_chart, verra_fallback_note):
 
     if verra_fallback_note != "":
         header = dbc.Row(
@@ -27,19 +26,62 @@ def create_offchain_vs_onchain_content(bridges_info_dict, df_verra,
                 ]), width=12, style={'textAlign': 'center'}),
         )
 
-    sum_total_tokenized = sum(d['Tokenized Quantity']
+    sum_total_tokenized = sum(d['Dataframe']['Quantity'].sum()
                               for d in bridges_info_dict.values())
+    sum_total_onchain_retired = sum(d['Dataframe']['Quantity'].sum()
+                                    for d in retires_info_dict.values())
+
+    offchain_retired_card = dbc.Col([
+        dbc.Card([
+            dbc.Col(
+                dbc.Card([
+                    html.H5('Off-Chain Verra Registry Credits Retired',
+                            className="card-title"),
+                    dbc.CardBody("{:,}".format(
+                        int(df_verra_retired['Quantity'].sum())), className="card-text")
+                ], style={'margin': '0px', 'padding': '0px'}), width=12),
+            dbc.Col(
+                dbc.Card([
+                    html.H5("Percentage of Retired Credits",
+                            className="card-title"),
+                    dbc.CardBody("{:.2%}".format(
+                        df_verra_retired['Quantity'].sum()/(df_verra['Quantity'].sum() - sum_total_tokenized)),
+                        className="card-text")
+                ], style={'margin': '0px', 'padding': '0px'}), width=12),
+        ])
+    ], lg=6, md=12)
+
+    onchain_retired_card = dbc.Col([
+        dbc.Card([
+            dbc.Col(
+                dbc.Card([
+                    html.H5('On-Chain Verra Registry Credits Retired',
+                            className="card-title"),
+                    dbc.CardBody("{:,}".format(
+                        int(sum_total_onchain_retired)), className="card-text")
+                ], style={'margin': '0px', 'padding': '0px'}), width=12),
+            dbc.Col(
+                dbc.Card([
+                    html.H5("Percentage of Retired Credits",
+                            className="card-title"),
+                    dbc.CardBody("{:.2%}".format(
+                        sum_total_onchain_retired/sum_total_tokenized),
+                        className="card-text")
+                ], style={'margin': '0px', 'padding': '0px'}), width=12),
+        ])
+    ], lg=6, md=12)
+
     content = [
         header,
         dbc.Row([
             dbc.Col(dbc.Card([
-                html.H5("Verra Registry Credits Ever Issued",
+                html.H5("Verra Registry Credits Issued",
                         className="card-title"),
                 dbc.CardBody("{:,}".format(
                     int(df_verra["Quantity"].sum())), className="card-text")
             ]), lg=4, md=12),
             dbc.Col(dbc.Card([
-                html.H5("Verra Registry Credits Ever Tokenized",
+                html.H5("Verra Registry Credits Tokenized",
                         className="card-title"),
                 dbc.CardBody("{:,}".format(
                     int(sum_total_tokenized)), className="card-text")
@@ -51,7 +93,11 @@ def create_offchain_vs_onchain_content(bridges_info_dict, df_verra,
                     (sum_total_tokenized / df_verra["Quantity"].sum())),
                     className="card-text")
             ]), lg=4, md=12),
-        ], style={'paddingTop': '60px'}),
+        ], style={'padding-top': '60px'}),
+        dbc.Row([
+            offchain_retired_card,
+            onchain_retired_card
+        ]),
 
         dbc.Row([
             dbc.Col([
@@ -62,30 +108,75 @@ def create_offchain_vs_onchain_content(bridges_info_dict, df_verra,
                 ])
             ], width=12),
         ]),
+
+        dbc.Row([
+            dbc.Col(),
+            dbc.Col([
+                dbc.Card([
+                    dbc.CardHeader(html.H2("Deep Dive into Off-Chain vs On-Chain Comparison")),
+                    dbc.CardBody([
+                        dbc.Row([
+                            dbc.Col([
+                                dbc.Card([
+                                    dbc.CardHeader(
+                                        html.H5("Issued or Retired Credits?", className="card-title"),),
+                                    dbc.CardBody([dcc.Dropdown(options=[{'label': 'Issued', 'value': 'Issued'},
+                                                                        {'label': 'Retired', 'value': 'Retired'}],
+                                                               value='Issued', id='issued_or_retired',
+                                                               placeholder='Select Summary Type')])
+                                ])
+                            ], lg=12, md=12),
+                        ])
+                    ])
+                ]),
+            ], width=12),
+            dbc.Col()
+        ], style={'paddingTop': '60px'}),
+
+
         dbc.Row([
             dbc.Col([
                 dbc.Card([
-                    html.H5("Credits Tokenized vs. Credits Issued by Vintage Start Dates",
+                    html.H5(id='offchain-volume-title',
                             className="card-title"),
-                    dbc.CardBody(dcc.Graph(figure=fig_on_vs_off_vintage))
+                    dbc.CardBody(dcc.Graph(id='offchain-volume-plot'))
+                ])
+            ], width=12),
+        ]),
+
+        dbc.Row([
+            dbc.Col([
+                dbc.Card([
+                    html.H5(id='onchain-volume-title',
+                            className="card-title"),
+                    dbc.CardBody(dcc.Graph(id='onchain-volume-plot'))
                 ])
             ], width=12),
         ]),
         dbc.Row([
             dbc.Col([
                 dbc.Card([
-                    html.H5("Credits Tokenized vs. Credits Issued by Origin",
+                    html.H5(id='on_vs_off_vintage_title',
                             className="card-title"),
-                    dbc.CardBody(dcc.Graph(figure=fig_on_vs_off_map))
+                    dbc.CardBody(dcc.Graph(id='on_vs_off_vintage_plot'))
                 ])
             ], width=12),
         ]),
         dbc.Row([
             dbc.Col([
                 dbc.Card([
-                    html.H5("Credits Tokenized vs. Credits Issued by Project Type",
+                    html.H5(id='on_vs_off_origin_title',
                             className="card-title"),
-                    dbc.CardBody(dcc.Graph(figure=fig_on_vs_off_project))
+                    dbc.CardBody(dcc.Graph(id='on_vs_off_origin_plot'))
+                ])
+            ], width=12),
+        ]),
+        dbc.Row([
+            dbc.Col([
+                dbc.Card([
+                    html.H5(id='on_vs_off_project_title',
+                            className="card-title"),
+                    dbc.CardBody(dcc.Graph(id='on_vs_off_project_plot'))
                 ])
             ], width=12),
         ]),

--- a/src/apps/tco2_dashboard/offchain_vs_onchain.py
+++ b/src/apps/tco2_dashboard/offchain_vs_onchain.py
@@ -113,7 +113,8 @@ def create_offchain_vs_onchain_content(bridges_info_dict, retires_info_dict, df_
             dbc.Col(),
             dbc.Col([
                 dbc.Card([
-                    dbc.CardHeader(html.H2("Deep Dive into Off-Chain vs On-Chain Comparison")),
+                    dbc.CardHeader(
+                        html.H2("Deep Dive into Off-Chain vs On-Chain Carbon Credits")),
                     dbc.CardBody([
                         dbc.Row([
                             dbc.Col([
@@ -158,7 +159,9 @@ def create_offchain_vs_onchain_content(bridges_info_dict, retires_info_dict, df_
                 dbc.Card([
                     html.H5(id='on_vs_off_vintage_title',
                             className="card-title"),
-                    dbc.CardBody(dcc.Graph(id='on_vs_off_vintage_plot'))
+                    dbc.CardBody(dcc.Graph(id='on_vs_off_vintage_plot')),
+                    dbc.CardFooter(id='on_vs_off_vintage_footer',
+                                   className='on_vs_off_footers'),
                 ])
             ], width=12),
         ]),
@@ -167,7 +170,9 @@ def create_offchain_vs_onchain_content(bridges_info_dict, retires_info_dict, df_
                 dbc.Card([
                     html.H5(id='on_vs_off_origin_title',
                             className="card-title"),
-                    dbc.CardBody(dcc.Graph(id='on_vs_off_origin_plot'))
+                    dbc.CardBody(dcc.Graph(id='on_vs_off_origin_plot')),
+                    dbc.CardFooter(id='on_vs_off_origin_footer',
+                                   className='on_vs_off_footers'),
                 ])
             ], width=12),
         ]),
@@ -176,7 +181,9 @@ def create_offchain_vs_onchain_content(bridges_info_dict, retires_info_dict, df_
                 dbc.Card([
                     html.H5(id='on_vs_off_project_title',
                             className="card-title"),
-                    dbc.CardBody(dcc.Graph(id='on_vs_off_project_plot'))
+                    dbc.CardBody(dcc.Graph(id='on_vs_off_project_plot')),
+                    dbc.CardFooter(id='on_vs_off_project_footer',
+                                   className='on_vs_off_footers'),
                 ])
             ], width=12),
         ]),


### PR DESCRIPTION
In this PR, I have;

1) Incorporated Eth-bridged-subgraph to bring in Moss bridged and retired credits info; (timestamp, value)
2) Incorporated a specific Moss-subgraph to bring in Moss Bridged Credits metadata; (serialNumber, Project ID, Vintage, etc)
3) Created on_vs_off retirement section: This includes on-chain retirement info and off-chain retirements info
4) Add color changes to on_vs_off treemaps

Note: We cant get project info on MCO2 retirements through any contract, so we just have timestamps and value of MCO2 retirements.
Resolve #36 