### PR TITLE
Add UBO,NBO prices, use price subgraph, add selective cost prices, and some nitpicks

### DIFF
--- a/src/abis/s3PoolToken.json
+++ b/src/abis/s3PoolToken.json
@@ -1,0 +1,1351 @@
+[
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "_address",
+                "type": "address"
+            }
+        ],
+        "name": "AddedERC20Banned",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "propertyType",
+                "type": "string"
+            },
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "value",
+                "type": "string"
+            }
+        ],
+        "name": "AddedProperty",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "_address",
+                "type": "address"
+            }
+        ],
+        "name": "AddedThirdPartyERC20WhiteList",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "previousAdmin",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "newAdmin",
+                "type": "address"
+            }
+        ],
+        "name": "AdminChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Approval",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "beacon",
+                "type": "address"
+            }
+        ],
+        "name": "BeaconUpgraded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "tokenERC2OAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "Deposited",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "previousOwner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferred",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "Paused",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "walletAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "tokenERC2OAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "Redeemed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc20Contract",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RedeemedFee",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "_address",
+                "type": "address"
+            }
+        ],
+        "name": "RemovedERC20Banned",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "propertyType",
+                "type": "string"
+            },
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "value",
+                "type": "string"
+            }
+        ],
+        "name": "RemovedProperty",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "_address",
+                "type": "address"
+            }
+        ],
+        "name": "RemovedThirdPartyERC20WhiteList",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "previousAdminRole",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "newAdminRole",
+                "type": "bytes32"
+            }
+        ],
+        "name": "RoleAdminChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleGranted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleRevoked",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Transfer",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "Unpaused",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "vintage",
+                "type": "uint256"
+            }
+        ],
+        "name": "UpdatedFeeRedeem",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "vintage",
+                "type": "uint256"
+            }
+        ],
+        "name": "UpdatedMinimumVintage",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "propertery",
+                "type": "string"
+            },
+            {
+                "indexed": false,
+                "internalType": "enum BasePool.OptionsSelection",
+                "name": "options",
+                "type": "uint8"
+            }
+        ],
+        "name": "UpdatedSelectionProperties",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "implementation",
+                "type": "address"
+            }
+        ],
+        "name": "Upgraded",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "DEFAULT_ADMIN_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "SUPERVISOR_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            }
+        ],
+        "name": "allowance",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "approve",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "balanceOf",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "_addresses",
+                "type": "address[]"
+            },
+            {
+                "internalType": "bool",
+                "name": "remove",
+                "type": "bool"
+            }
+        ],
+        "name": "changeERC20Banned",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "property",
+                "type": "string"
+            },
+            {
+                "internalType": "string[]",
+                "name": "_inputs",
+                "type": "string[]"
+            },
+            {
+                "internalType": "bool",
+                "name": "remove",
+                "type": "bool"
+            }
+        ],
+        "name": "changeProperty",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "_addresses",
+                "type": "address[]"
+            },
+            {
+                "internalType": "bool",
+                "name": "remove",
+                "type": "bool"
+            }
+        ],
+        "name": "changeThirdPartyWhiteList",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [
+            {
+                "internalType": "uint8",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "subtractedValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "decreaseAllowance",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_erc20",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "deposit",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "erc20TokensBalances",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "feeRedeem",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "feeRedeemAddress",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "freeRedeem",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getERC20Banned",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "",
+                "type": "address[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getERC20ThirdPartyWhiteList",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "",
+                "type": "address[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getERC20Tokens",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "",
+                "type": "address[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getFreeRedeemAddresses",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "",
+                "type": "address[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "property",
+                "type": "string"
+            }
+        ],
+        "name": "getProperty",
+        "outputs": [
+            {
+                "internalType": "string[]",
+                "name": "",
+                "type": "string[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getRoleAdmin",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "grantRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "hasRole",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "addedValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "increaseAllowance",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "internalType": "string",
+                "name": "symbol",
+                "type": "string"
+            },
+            {
+                "internalType": "address",
+                "name": "_orchestratorAddress",
+                "type": "address"
+            }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_address",
+                "type": "address"
+            }
+        ],
+        "name": "isERC20Suitable",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "isSupervisor",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "isIndeed",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_address",
+                "type": "address"
+            },
+            {
+                "internalType": "bool",
+                "name": "remove",
+                "type": "bool"
+            }
+        ],
+        "name": "manageFreeRedeemAddresses",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "minimumVintageYear",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "name",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "optionsSelectionCountries",
+        "outputs": [
+            {
+                "internalType": "enum BasePool.OptionsSelection",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "optionsSelectionMethodologies",
+        "outputs": [
+            {
+                "internalType": "enum BasePool.OptionsSelection",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "optionsSelectionProjectId",
+        "outputs": [
+            {
+                "internalType": "enum BasePool.OptionsSelection",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "optionsSelectionRegions",
+        "outputs": [
+            {
+                "internalType": "enum BasePool.OptionsSelection",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "optionsSelectionRegistry",
+        "outputs": [
+            {
+                "internalType": "enum BasePool.OptionsSelection",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "optionsSelectionType",
+        "outputs": [
+            {
+                "internalType": "enum BasePool.OptionsSelection",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "orchestratorAddress",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "pause",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "paused",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "renounceOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "renounceRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "revokeRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_redeem",
+                "type": "uint256"
+            }
+        ],
+        "name": "setFeeRedeem",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "addresses",
+                "type": "address[]"
+            }
+        ],
+        "name": "setFreeRedeemAddresses",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_minimumVintageYear",
+                "type": "uint256"
+            }
+        ],
+        "name": "setMinimumVintageYear",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "property",
+                "type": "string"
+            },
+            {
+                "internalType": "enum BasePool.OptionsSelection",
+                "name": "_optionsSelect",
+                "type": "uint8"
+            }
+        ],
+        "name": "setOptionsSelection",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_address",
+                "type": "address"
+            }
+        ],
+        "name": "setRedeemAddress",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "erc20Addresses",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "amount",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "taxedRedeem",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transfer",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transferFrom",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "unpause",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newImplementation",
+                "type": "address"
+            }
+        ],
+        "name": "upgradeTo",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newImplementation",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "upgradeToAndCall",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    }
+]

--- a/src/abis/toucanPoolToken.json
+++ b/src/abis/toucanPoolToken.json
@@ -1,0 +1,1923 @@
+[
+    {
+        "inputs": [],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "tco2",
+                "type": "address"
+            }
+        ],
+        "name": "AddFeeExemptedTCO2",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "previousAdmin",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "newAdmin",
+                "type": "address"
+            }
+        ],
+        "name": "AdminChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Approval",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "methodology",
+                "type": "string"
+            }
+        ],
+        "name": "AttributeMethodologyAdded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "methodology",
+                "type": "string"
+            }
+        ],
+        "name": "AttributeMethodologyRemoved",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "region",
+                "type": "string"
+            }
+        ],
+        "name": "AttributeRegionAdded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "region",
+                "type": "string"
+            }
+        ],
+        "name": "AttributeRegionRemoved",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "standard",
+                "type": "string"
+            }
+        ],
+        "name": "AttributeStandardAdded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "standard",
+                "type": "string"
+            }
+        ],
+        "name": "AttributeStandardRemoved",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "beacon",
+                "type": "address"
+            }
+        ],
+        "name": "BeaconUpgraded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc20Addr",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "Deposited",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc20addr",
+                "type": "address"
+            }
+        ],
+        "name": "ExternalAddressRemovedFromWhitelist",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc20addr",
+                "type": "address"
+            }
+        ],
+        "name": "ExternalAddressWhitelisted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint8",
+                "name": "version",
+                "type": "uint8"
+            }
+        ],
+        "name": "Initialized",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc20addr",
+                "type": "address"
+            }
+        ],
+        "name": "InternalAddressBlacklisted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc20addr",
+                "type": "address"
+            }
+        ],
+        "name": "InternalAddressRemovedFromBlackList",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc20addr",
+                "type": "address"
+            }
+        ],
+        "name": "InternalAddressRemovedFromWhitelist",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc20addr",
+                "type": "address"
+            }
+        ],
+        "name": "InternalAddressWhitelisted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "mappingName",
+                "type": "string"
+            },
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "accepted",
+                "type": "bool"
+            }
+        ],
+        "name": "MappingSwitched",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "minimumVintageStartTime",
+                "type": "uint256"
+            }
+        ],
+        "name": "MinimumVintageStartTimeUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "previousOwner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferred",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "Paused",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "redeemer",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "fees",
+                "type": "uint256"
+            }
+        ],
+        "name": "RedeemFeeBurnt",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "redeemer",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "fees",
+                "type": "uint256"
+            }
+        ],
+        "name": "RedeemFeePaid",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "erc20",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "Redeemed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "tco2",
+                "type": "address"
+            }
+        ],
+        "name": "RemoveFeeExemptedTCO2",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "previousAdminRole",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "newAdminRole",
+                "type": "bytes32"
+            }
+        ],
+        "name": "RoleAdminChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleGranted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleRevoked",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "newCap",
+                "type": "uint256"
+            }
+        ],
+        "name": "SupplyCapUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address[]",
+                "name": "tco2s",
+                "type": "address[]"
+            }
+        ],
+        "name": "TCO2ScoringUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "ContractRegistry",
+                "type": "address"
+            }
+        ],
+        "name": "ToucanRegistrySet",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Transfer",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "Unpaused",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "implementation",
+                "type": "address"
+            }
+        ],
+        "name": "Upgraded",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "DEFAULT_ADMIN_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "MANAGER_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "PAUSER_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bool",
+                "name": "addToList",
+                "type": "bool"
+            },
+            {
+                "internalType": "string[]",
+                "name": "_regions",
+                "type": "string[]"
+            },
+            {
+                "internalType": "string[]",
+                "name": "_standards",
+                "type": "string[]"
+            },
+            {
+                "internalType": "string[]",
+                "name": "_methodologies",
+                "type": "string[]"
+            }
+        ],
+        "name": "addAttributes",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_address",
+                "type": "address"
+            }
+        ],
+        "name": "addRedeemFeeExemptedAddress",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_tco2",
+                "type": "address"
+            }
+        ],
+        "name": "addRedeemFeeExemptedTCO2",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "erc20Addr",
+                "type": "address[]"
+            }
+        ],
+        "name": "addToExternalWhiteList",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "erc20Addr",
+                "type": "address[]"
+            }
+        ],
+        "name": "addToInternalBlackList",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "erc20Addr",
+                "type": "address[]"
+            }
+        ],
+        "name": "addToInternalWhiteList",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            }
+        ],
+        "name": "allowance",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "approve",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "balanceOf",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_account",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "bridgeBurn",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_account",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "bridgeMint",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "tco2s",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "amounts",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "calculateRedeemFees",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "erc20Addr",
+                "type": "address"
+            }
+        ],
+        "name": "checkAttributeMatching",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "erc20Addr",
+                "type": "address"
+            }
+        ],
+        "name": "checkEligible",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "contractRegistry",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [
+            {
+                "internalType": "uint8",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "subtractedValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "decreaseAllowance",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "erc20Addr",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "deposit",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "externalWhiteList",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "feeRedeemBurnAddress",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "feeRedeemBurnPercentageInBase",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "feeRedeemDivider",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "feeRedeemPercentageInBase",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "feeRedeemReceiver",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getRemaining",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getRoleAdmin",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getScoredTCO2s",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "",
+                "type": "address[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "grantRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "hasRole",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "addedValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "increaseAllowance",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "internalBlackList",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "internalWhiteList",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "name": "methodologies",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "methodologiesIsAcceptedMapping",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "minimumVintageStartTime",
+        "outputs": [
+            {
+                "internalType": "uint64",
+                "name": "",
+                "type": "uint64"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "name",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "pause",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "paused",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "proxiableUUID",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "tco2",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "redeemAndBurn",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "redeemAuto",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "redeemAuto2",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "tco2s",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "amounts",
+                "type": "uint256[]"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "redeemFeeExemptedAddresses",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "redeemFeeExemptedTCO2s",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "tco2s",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "amounts",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "redeemMany",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "name": "regions",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "regionsIsAcceptedMapping",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "erc20Addr",
+                "type": "address[]"
+            }
+        ],
+        "name": "removeFromExternalWhiteList",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "erc20Addr",
+                "type": "address[]"
+            }
+        ],
+        "name": "removeFromInternalBlackList",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "erc20Addr",
+                "type": "address[]"
+            }
+        ],
+        "name": "removeFromInternalWhiteList",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_address",
+                "type": "address"
+            }
+        ],
+        "name": "removeRedeemFeeExemptedAddress",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_tco2",
+                "type": "address"
+            }
+        ],
+        "name": "removeRedeemFeeExemptedTCO2",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "renounceOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "renounceRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "revokeRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "router",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "name": "scoredTCO2s",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_feeRedeemBurnAddress",
+                "type": "address"
+            }
+        ],
+        "name": "setFeeRedeemBurnAddress",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_feeRedeemBurnPercentageInBase",
+                "type": "uint256"
+            }
+        ],
+        "name": "setFeeRedeemBurnPercentage",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_feeRedeemPercentageInBase",
+                "type": "uint256"
+            }
+        ],
+        "name": "setFeeRedeemPercentage",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_feeRedeemReceiver",
+                "type": "address"
+            }
+        ],
+        "name": "setFeeRedeemReceiver",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint64",
+                "name": "_minimumVintageStartTime",
+                "type": "uint64"
+            }
+        ],
+        "name": "setMinimumVintageStartTime",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_router",
+                "type": "address"
+            }
+        ],
+        "name": "setRouter",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "newCap",
+                "type": "uint256"
+            }
+        ],
+        "name": "setSupplyCap",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "tco2s",
+                "type": "address[]"
+            }
+        ],
+        "name": "setTCO2Scoring",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_address",
+                "type": "address"
+            }
+        ],
+        "name": "setToucanContractRegistry",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "name": "standards",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "standardsIsAcceptedMapping",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "supplyCap",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "_mappingName",
+                "type": "string"
+            },
+            {
+                "internalType": "bool",
+                "name": "accepted",
+                "type": "bool"
+            }
+        ],
+        "name": "switchMapping",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "tokenBalances",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transfer",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transferFrom",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "unpause",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newImplementation",
+                "type": "address"
+            }
+        ],
+        "name": "upgradeTo",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newImplementation",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "upgradeToAndCall",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "version",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    }
+]

--- a/src/apps/tco2_dashboard/app.py
+++ b/src/apps/tco2_dashboard/app.py
@@ -9,7 +9,7 @@ import pandas as pd
 import requests
 from subgrounds.subgrounds import Subgrounds
 from subgrounds.subgraph import SyntheticField
-from pycoingecko import CoinGeckoAPI
+from ...util import get_polygon_web3
 
 from src.apps.tco2_dashboard.carbon_supply import create_carbon_supply_content
 
@@ -68,6 +68,7 @@ from .helpers import (
     create_holders_data,
     merge_retirements_data_for_retirement_chart,
     retirmentManualAdjustments,
+    add_fee_redeem_factors_to_dict,
 )
 from .constants import (
     rename_map,
@@ -90,6 +91,11 @@ from .constants import (
     bridges_rename_map,
     holders_rename_map,
     moss_retires_rename_map,
+    BCT_USDC_ADDRESS,
+    NCT_USDC_ADDRESS,
+    KLIMA_MCO2_ADDRESS,
+    KLIMA_NBO_ADDRESS,
+    KLIMA_UBO_ADDRESS,
 )
 
 CACHE_TIMEOUT = 86400
@@ -111,10 +117,14 @@ CARBON_CELO_SUBGRAPH_URL = (
 CARBON_HOLDERS_SUBGRAPH_URL = (
     "https://api.thegraph.com/subgraphs/name/klimadao/klimadao-user-carbon"
 )
+PAIRS_SUBGRAPH_URL = (
+    "https://api.thegraph.com/subgraphs/name/originalpkbims/klimapairs-price-test"
+)
 MAX_RECORDS = 1000000
 PRICE_DAYS = 5000
 GOOGLE_API_ICONS = {
-    "href": "https://fonts.googleapis.com/icon?family=Material+Icons",
+    "href": "https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined|"
+    "Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp",
     "rel": "stylesheet",
 }
 POPPINS_FONT = {
@@ -178,7 +188,8 @@ app = dash.Dash(
 
 
 # Add GTM for analytics via index_string
-gtm_head_section = '''
+gtm_head_section = (
+    """
         <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -186,27 +197,39 @@ gtm_head_section = '''
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-KWFJ9R2');</script>
         <!-- End Google Tag Manager -->
-''' if os.environ.get("ENV") == "Production" else ''
+"""
+    if os.environ.get("ENV") == "Production"
+    else ""
+)
 
-gtm_body_section = '''
+gtm_body_section = (
+    """
         <!-- Google Tag Manager (noscript) -->
         <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KWFJ9R2"
         height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <!-- End Google Tag Manager (noscript) -->
-''' if os.environ.get("ENV") == "Production" else ''
+"""
+    if os.environ.get("ENV") == "Production"
+    else ""
+)
 
-app.index_string = '''
+app.index_string = (
+    """
 <!DOCTYPE html>
 <html>
     <head>
-''' + gtm_head_section + '''
+"""
+    + gtm_head_section
+    + """
         {%metas%}
         <title>{%title%}</title>
         {%favicon%}
         {%css%}
     </head>
     <body>
-''' + gtm_body_section + '''
+"""
+    + gtm_body_section
+    + """
         {%app_entry%}
         <footer>
             {%config%}
@@ -215,7 +238,8 @@ app.index_string = '''
         </footer>
     </body>
 </html>
-'''
+"""
+)
 
 
 # Configure cache
@@ -474,10 +498,10 @@ def get_eth_carbon_metrics():
     )
 
     carbonMetrics = carbon_data.Query.carbonMetrics(
-        orderBy=carbon_data.CarbonMetric.timestamp, orderDirection="desc", first=MAX_RECORDS,
-        where=[
-            carbon_data.CarbonMetric.timestamp > 0
-        ]
+        orderBy=carbon_data.CarbonMetric.timestamp,
+        orderDirection="desc",
+        first=MAX_RECORDS,
+        where=[carbon_data.CarbonMetric.timestamp > 0],
     )
 
     df = sg.query_df(
@@ -493,7 +517,7 @@ def get_eth_carbon_metrics():
         ]
     )
 
-    zeroTimestampIndex = df[(df['carbonMetrics_timestamp'] == "0")].index
+    zeroTimestampIndex = df[(df["carbonMetrics_timestamp"] == "0")].index
     df.drop(zeroTimestampIndex, inplace=True)
 
     return df
@@ -512,10 +536,10 @@ def get_celo_carbon_metrics():
     )
 
     carbonMetrics = carbon_data.Query.carbonMetrics(
-        orderBy=carbon_data.CarbonMetric.timestamp, orderDirection="desc", first=MAX_RECORDS,
-        where=[
-            carbon_data.CarbonMetric.timestamp > 0
-        ]
+        orderBy=carbon_data.CarbonMetric.timestamp,
+        orderDirection="desc",
+        first=MAX_RECORDS,
+        where=[carbon_data.CarbonMetric.timestamp > 0],
     )
 
     df = sg.query_df(
@@ -548,8 +572,8 @@ def get_polygon_carbon_metrics():
     )
 
     carbon_data.CarbonMetric.not_klima_retired = SyntheticField(
-        lambda totalRetirements, totalKlimaRetirements:
-            totalRetirements - totalKlimaRetirements,
+        lambda totalRetirements, totalKlimaRetirements: totalRetirements
+        - totalKlimaRetirements,
         SyntheticField.FLOAT,
         [
             carbon_data.CarbonMetric.totalRetirements,
@@ -558,10 +582,10 @@ def get_polygon_carbon_metrics():
     )
 
     carbonMetrics = carbon_data.Query.carbonMetrics(
-        orderBy=carbon_data.CarbonMetric.timestamp, orderDirection="desc", first=MAX_RECORDS,
-        where=[
-            carbon_data.CarbonMetric.timestamp > 0
-        ]
+        orderBy=carbon_data.CarbonMetric.timestamp,
+        orderDirection="desc",
+        first=MAX_RECORDS,
+        where=[carbon_data.CarbonMetric.timestamp > 0],
     )
 
     df = sg.query_df(
@@ -585,61 +609,78 @@ def get_polygon_carbon_metrics():
             carbonMetrics.uboKlimaRetired,
             carbonMetrics.nboKlimaRetired,
             carbonMetrics.totalKlimaRetirements,
-            carbonMetrics.not_klima_retired
+            carbonMetrics.not_klima_retired,
         ]
     )
 
     return df
 
 
-# web3 = get_eth_web3() if os.environ.get('WEB3_INFURA_PROJECT_ID') else None
+web3 = get_polygon_web3() if os.environ.get("WEB3_INFURA_PROJECT_ID") else None
 
-
-# def get_mco2_contract_data():
-#     ERC20_ABI = load_abi('erc20.json')
-#     if web3 is not None:
-#         mco2_contract = web3.eth.contract(address=MCO2_ADDRESS, abi=ERC20_ABI)
-#         decimals = 10 ** mco2_contract.functions.decimals().call()
-#         total_supply = mco2_contract.functions.totalSupply().call() // decimals
-#         return total_supply
-#     else:
-#         # If web3 is not connected, just return an invalid value
-#         return -1
-
-
-cg = CoinGeckoAPI()
-token_cg_dict = {
+tokens_dict = {
     "BCT": {
         "address": BCT_ADDRESS,
         "id": "polygon-pos",
+        "Pair Address": BCT_USDC_ADDRESS,
+        "Token Address": BCT_ADDRESS,
         "Full Name": "Base Carbon Tonne",
     },
     "NCT": {
         "address": NCT_ADDRESS,
         "id": "polygon-pos",
+        "Pair Address": NCT_USDC_ADDRESS,
+        "Token Address": NCT_ADDRESS,
         "Full Name": "Nature Carbon Tonne",
     },
     "MCO2": {
         "address": MCO2_ADDRESS,
         "id": "ethereum",
+        "Pair Address": KLIMA_MCO2_ADDRESS,
+        "Token Address": MCO2_ADDRESS,
         "Full Name": "Moss Carbon Credit",
+    },
+    "UBO": {
+        "Pair Address": KLIMA_UBO_ADDRESS,
+        "Token Address": UBO_ADDRESS,
+        "Full Name": "Universal Basic Offset",
+    },
+    "NBO": {
+        "Pair Address": KLIMA_NBO_ADDRESS,
+        "Token Address": NBO_ADDRESS,
+        "Full Name": "Nature Based Offset",
     },
 }
 
 
 @cache.memoize()
 def get_prices():
+    sg = Subgrounds()
+    price_sg = sg.load_subgraph(PAIRS_SUBGRAPH_URL)
     df_prices = pd.DataFrame()
-    for i in token_cg_dict.keys():
-        data = cg.get_coin_market_chart_from_contract_address_by_id(
-            id=token_cg_dict[i]["id"],
-            vs_currency="usd",
-            contract_address=token_cg_dict[i]["address"],
-            days=PRICE_DAYS,
+    for i in tokens_dict.keys():
+        swaps = price_sg.Query.swaps(
+            first=MAX_RECORDS,
+            orderBy=price_sg.Swap.timestamp,
+            orderDirection="desc",
+            where=[price_sg.Swap.pair == tokens_dict[i]["Pair Address"]],
         )
-        df = pd.DataFrame(data["prices"], columns=["Date", f"{i}_Price"])
-        df["Date"] = pd.to_datetime(df["Date"], unit="ms")
-        df["Date"] = df["Date"].dt.floor("D")
+
+        df = sg.query_df([swaps.pair.id, swaps.close, swaps.timestamp])
+        rename_prices_map = {
+            "swaps_pair_id": f"{i}_Address",
+            "swaps_close": f"{i}_Price",
+            "swaps_timestamp": "Date",
+        }
+        df = df.rename(columns=rename_prices_map)
+        df["Date"] = (
+            pd.to_datetime(df["Date"], unit="s")
+            .dt.tz_localize("UTC")
+            .dt.floor("D")
+            .dt.date
+        )
+        df = df.drop_duplicates(keep="first", subset=[f"{i}_Address", "Date"])
+        df = df[df[f"{i}_Price"] != 0]
         if df_prices.empty:
             df_prices = df
         else:
@@ -796,9 +837,8 @@ def generate_layout():
     eth_carbon_metrics_df = get_eth_carbon_metrics()
     celo_carbon_metrics_df = get_celo_carbon_metrics()
     content_carbon_supply = create_carbon_supply_content(
-        polygon_carbon_metrics_df,
-        eth_carbon_metrics_df,
-        celo_carbon_metrics_df)
+        polygon_carbon_metrics_df, eth_carbon_metrics_df, celo_carbon_metrics_df
+    )
 
     cache.set("content_carbon_supply", content_carbon_supply)
 
@@ -1316,14 +1356,20 @@ def generate_layout():
 
     # ----Top Level Page---
 
-    token_cg_dict["BCT"]["Current Supply"] = (
+    tokens_dict["BCT"]["Current Supply"] = (
         bct_deposited["Quantity"].sum() - bct_redeemed["Quantity"].sum()
     )
-    token_cg_dict["NCT"]["Current Supply"] = (
+    tokens_dict["NCT"]["Current Supply"] = (
         nct_deposited["Quantity"].sum() - nct_redeemed["Quantity"].sum()
     )
-    token_cg_dict["MCO2"]["Current Supply"] = (
+    tokens_dict["MCO2"]["Current Supply"] = (
         df_bridged_mco2["Quantity"].sum() - df_retired_mco2["Quantity"].sum()
+    )
+    tokens_dict["UBO"]["Current Supply"] = (
+        ubo_deposited["Quantity"].sum() - ubo_redeemed["Quantity"].sum()
+    )
+    tokens_dict["NBO"]["Current Supply"] = (
+        nbo_deposited["Quantity"].sum() - nbo_redeemed["Quantity"].sum()
     )
 
     bridges_info_dict = {
@@ -1411,9 +1457,10 @@ def generate_layout():
     cache.set("content_offchain_vs_onchain", content_offchain_vs_onchain)
 
     # --- onchain carbon pool comparison ---
-    fig_historical_prices = historical_prices(token_cg_dict, df_prices)
+    add_fee_redeem_factors_to_dict(tokens_dict, web3)
+    fig_historical_prices = historical_prices(tokens_dict, df_prices)
     content_onchain_pool_comp = create_onchain_pool_comp_content(
-        token_cg_dict, df_prices, fig_historical_prices
+        tokens_dict, df_prices, fig_historical_prices
     )
     cache.set("content_onchain_pool_comp", content_onchain_pool_comp)
 
@@ -1524,9 +1571,9 @@ def generate_layout():
                                 html.Span("balance", className="material-icons"),
                                 className="icon-container",
                             ),
-                            html.Span("Carbon Pools", className="icon-title"),
+                            html.Span("Carbon Pricing", className="icon-title"),
                         ],
-                        href="/CarbonPools",
+                        href="/CarbonPricing",
                         active="exact",
                     ),
                     dbc.NavLink(
@@ -1714,9 +1761,9 @@ def generate_layout():
                                         ),
                                         className="icon-container",
                                     ),
-                                    html.Span("Carbon Pools", className="icon-title"),
+                                    html.Span("Carbon Pricing", className="icon-title"),
                                 ],
-                                href="/CarbonPools",
+                                href="/CarbonPricing",
                                 active="exact",
                                 id="button-onchain_pool_comp",
                                 n_clicks=0,
@@ -1729,7 +1776,10 @@ def generate_layout():
                                         ),
                                         className="icon-container",
                                     ),
-                                    html.Span("Blockchain Carbon Supply", className="icon-title"),
+                                    html.Span(
+                                        "Blockchain Carbon Supply",
+                                        className="icon-title",
+                                    ),
                                 ],
                                 href="/CarbonSupply",
                                 active="exact",
@@ -2303,7 +2353,7 @@ def render_page_content(pathname):
         content_offchain_vs_onchain = cache.get("content_offchain_vs_onchain")
         return content_offchain_vs_onchain
 
-    elif pathname == "/CarbonPools":
+    elif pathname == "/CarbonPricing":
         content_onchain_pool_comp = cache.get("content_onchain_pool_comp")
         return content_onchain_pool_comp
 

--- a/src/apps/tco2_dashboard/assets/styles.css
+++ b/src/apps/tco2_dashboard/assets/styles.css
@@ -69,6 +69,12 @@ a {
   border: 0px;
 }
 
+.pool_card{
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
 .card-pool-summary {
   background: var(--dark-gray);
   /* border: 2px solid #00CC33; */
@@ -292,10 +298,11 @@ color: white;
   font-style: italic;
 }
 
-#klima_retire_note{
+.card-footer{
   font-style: italic;
   font-size: 0.7rem;
   padding: 0px;
+  border: 0px;
 }
 
 .on_vs_off_footers{
@@ -639,7 +646,35 @@ p {
   background-color: var(--green);
 }
 
-.top-btns{
+.tooltip-icon-container{
+  align-items: center;
+  justify-content: center;
+  margin-top: 0rem;
+  height: 20px;
+  width: 20px;
+  display: flex;
+}
+
+.tooltip{
+  font-family: var(--font-fam);
+  font-weight: 400;
+  font-size: 1em;
+}
+
+.tooltip-inner{
+  background: #303030;
+}
+
+.card-title-with-tooltip{
+  justify-content: center;
+  align-items: center;
+}
+
+.card-title-with-tooltip .card-title{
+  margin: 0px;
+}
+
+.top-btns, .card-title-with-tooltip{
   display: flex;
   flex-direction: row;
   gap: 10px;

--- a/src/apps/tco2_dashboard/constants.py
+++ b/src/apps/tco2_dashboard/constants.py
@@ -10,6 +10,12 @@ MCO2_ADDRESS_MATIC = "0xaa7dbd1598251f856c12f63557a4c4397c253cea"
 VERRA_FALLBACK_NOTE = "Note: Off-Chain Verra Registry data is not updated, we are temporarily using fallback data"
 KLIMA_RETIRED_NOTE = "Note: This only includes Retired Tonnes coming through the KlimaDAO retirement aggregator tool"
 VERRA_FALLBACK_URL = "https://prod-klimadao-data.nyc3.digitaloceanspaces.com/verra_registry_fallback_data.csv"
+KLIMA_UBO_ADDRESS = "0x5400a05b8b45eaf9105315b4f2e31f806ab706de"
+KLIMA_NBO_ADDRESS = "0x251ca6a70cbd93ccd7039b6b708d4cb9683c266c"
+KLIMA_MCO2_ADDRESS = "0x64a3b8ca5a7e406a78e660ae10c7563d9153a739"
+KLIMA_BCT_ADDRESS = "0x9803c7ae526049210a1725f7487af26fe2c24614"
+BCT_USDC_ADDRESS = "0x1e67124681b402064cd0abe8ed1b5c79d2e02f64"
+NCT_USDC_ADDRESS = "0xdb995f975f1bfc3b2157495c47e4efb31196b2ca"
 
 rename_map = {
     "carbonOffsets_bridges_value": "Quantity",

--- a/src/apps/tco2_dashboard/figures.py
+++ b/src/apps/tco2_dashboard/figures.py
@@ -3,13 +3,12 @@ import plotly.graph_objects as go
 import numpy as np
 import pycountry
 from collections import defaultdict
-from .helpers import add_px_figure
+from .helpers import add_px_figure, human_format
 from plotly.subplots import make_subplots
 from .constants import FIGURE_BG_COLOR
 import pandas as pd
 import circlify
 import matplotlib
-from math import log, floor
 from base64 import b64encode
 import math
 
@@ -763,9 +762,9 @@ def verra_project(df_verra, df_verra_toucan):
     return fig
 
 
-def historical_prices(token_cg_dict, df_prices):
+def historical_prices(tokens_dict, df_prices):
     fig = go.Figure()
-    for i in token_cg_dict.keys():
+    for i in tokens_dict.keys():
         col_name = f"{i}_Price"
         filtered_df = df_prices[~df_prices[col_name].isna()]
         fig.add_trace(
@@ -1323,12 +1322,6 @@ def create_offchain_vs_onchain_fig(
     offchain_retired = df_offchain_retired["Quantity"].iat[-1]
     onchain_retired = df_onchain_retired["Quantity"].iat[-1]
 
-    def human_format(number):
-        units = ["", "K", "M", "G", "T", "P"]
-        k = 1000.0
-        magnitude = int(floor(log(number, k)))
-        return "%.0f%s" % (number / k**magnitude, units[magnitude])
-
     label_value = [
         human_format(issued),
         human_format(offchain_retired),
@@ -1618,13 +1611,14 @@ def get_supply_breakdown_figure(allowed_tokens, df):
         col_name = f"carbonMetrics_{allowed_token['name']}Supply"
         fig.add_trace(
             go.Scatter(
-                name=allowed_token['name'].upper(),
+                name=allowed_token["name"].upper(),
                 x=df["carbonMetrics_datetime"],
                 y=df[col_name],
                 mode="lines",
                 stackgroup="one",
-                line={'width': 0.5, 'color': allowed_token['color']},
-            ))
+                line={"width": 0.5, "color": allowed_token["color"]},
+            )
+        )
 
     fig.update_layout(
         height=300,
@@ -1647,14 +1641,24 @@ def get_polygon_retirement_breakdown_figure(df):
     fig = go.Figure()
     fig.add_trace(
         go.Scatter(
-            x=df["carbonMetrics_datetime"], y=df["carbonMetrics_totalKlimaRetirements"],
-            mode="lines", name="Retired via KlimaDAO", stackgroup="one", line={'width': 0.5, 'color': '#536C9C'},
-        ))
+            x=df["carbonMetrics_datetime"],
+            y=df["carbonMetrics_totalKlimaRetirements"],
+            mode="lines",
+            name="Retired via KlimaDAO",
+            stackgroup="one",
+            line={"width": 0.5, "color": "#536C9C"},
+        )
+    )
     fig.add_trace(
         go.Scatter(
-            x=df["carbonMetrics_datetime"], y=df["carbonMetrics_not_klima_retired"],
-            mode="lines", name="Not Retired via KlimaDAO", stackgroup="one", line={'width': 0.5, 'color': '#c74b0e'},
-        )),
+            x=df["carbonMetrics_datetime"],
+            y=df["carbonMetrics_not_klima_retired"],
+            mode="lines",
+            name="Not Retired via KlimaDAO",
+            stackgroup="one",
+            line={"width": 0.5, "color": "#c74b0e"},
+        )
+    ),
 
     fig.update_layout(
         height=300,
@@ -1677,9 +1681,14 @@ def get_eth_retirement_breakdown_figure(df):
     fig = go.Figure()
     fig.add_trace(
         go.Scatter(
-            x=df["carbonMetrics_datetime"], y=df["carbonMetrics_totalRetirements"],
-            mode="lines", name="Not Retired by Klima", stackgroup="one", line={'width': 0.5, 'color': '#c74b0e'},
-        ))
+            x=df["carbonMetrics_datetime"],
+            y=df["carbonMetrics_totalRetirements"],
+            mode="lines",
+            name="Not Retired by Klima",
+            stackgroup="one",
+            line={"width": 0.5, "color": "#c74b0e"},
+        )
+    )
 
     fig.update_layout(
         height=300,

--- a/src/apps/tco2_dashboard/homepage.py
+++ b/src/apps/tco2_dashboard/homepage.py
@@ -2,17 +2,7 @@ from dash import html
 from dash import dcc
 import dash_bootstrap_components as dbc
 from datetime import date, datetime
-
-
-def human_format(num):
-    num = float("{:.3g}".format(num))
-    magnitude = 0
-    while abs(num) >= 1000:
-        magnitude += 1
-        num /= 1000.0
-    return "{}{}".format(
-        "{:f}".format(num).rstrip("0").rstrip("."), ["", "K", "M", "B", "T"][magnitude]
-    )
+from .helpers import human_format
 
 
 def getSocialShareFeature(clipboardId):

--- a/src/apps/tco2_dashboard/onchain_pool_comp.py
+++ b/src/apps/tco2_dashboard/onchain_pool_comp.py
@@ -3,55 +3,140 @@ from dash import dcc
 import dash_bootstrap_components as dbc
 
 
-def create_onchain_pool_comp_content(token_cg_dict, df_prices, fig_historical_prices):
+def create_onchain_pool_comp_content(tokens_dict, df_prices, fig_historical_prices):
 
+    historical_price_note = "Note: The chart shows MCO2 prices based on the KLIMA/MCO2 pool since it launched."
     pool_cards = []
-    for i in token_cg_dict.keys():
+    for i in tokens_dict.keys():
+        filtered_df = df_prices[~df_prices[f"{i}_Price"].isna()]
+        if i == "MCO2":
+            selective_cost_value = "NA"
+            selective_cost_tooltip_text = (
+                "There is no selective reddeeming/retiring option for MCO2."
+            )
+        else:
+            selective_cost_tooltip_text = "This cost includes the asset spot price + the fee to \
+                selectively redeem or retire an underlying carbon project."
+            selective_cost_value = "${:.2f}".format(
+                filtered_df[f"{i}_Price"].iloc[0]
+                * (1 + tokens_dict[i]["Fee Redeem Factor"])
+            )
+
+        print(filtered_df[f"{i}_Price"])
         price_col = dbc.Col(
-            dbc.Card([
-                html.H5("Price", className="card-title"),
-                dbc.CardBody("${:.2f}".format(
-                    df_prices[f"{i}_Price"].iloc[0]), className="card-text")
-            ]), width=12)
+            dbc.Card(
+                [
+                    html.H5("Price", className="card-title"),
+                    dbc.CardBody(
+                        "${:.2f}".format(filtered_df[f"{i}_Price"].iloc[0]),
+                        className="card-text",
+                    ),
+                ]
+            ),
+            width=12,
+        )
+
+        selective_cost_col = dbc.Col(
+            dbc.Card(
+                [
+                    html.Div(
+                        [
+                            html.H5("Selective Cost", className="card-title"),
+                            html.Div(
+                                html.Span(
+                                    "info",
+                                    className="material-icons-outlined",
+                                    style={"font-size": "20px"},
+                                    id=f"selective-cost-tooltip_{i}",
+                                ),
+                                className="tooltip-icon-container",
+                            ),
+                            dbc.Tooltip(
+                                selective_cost_tooltip_text,
+                                target=f"selective-cost-tooltip_{i}",
+                                className="selective-cost-tooltip",
+                                placement="top",
+                                style={"background-color": "#303030"},
+                            ),
+                        ],
+                        className="card-title-with-tooltip",
+                    ),
+                    dbc.CardBody(
+                        selective_cost_value,
+                        className="card-text",
+                    ),
+                ]
+            ),
+            width=12,
+        )
 
         current_supply_col = dbc.Col(
-            dbc.Card([
-                html.H5("Current Supply", className="card-title"),
-                dbc.CardBody("{:,}".format(
-                    int(token_cg_dict[i]["Current Supply"])), className="card-text")
-            ]), width=12)
+            dbc.Card(
+                [
+                    html.H5("Current Supply", className="card-title"),
+                    dbc.CardBody(
+                        "{:,}".format(int(tokens_dict[i]["Current Supply"])),
+                        className="card-text",
+                    ),
+                ]
+            ),
+            width=12,
+        )
 
-        pool_card = dbc.Col([
-            dbc.Card([
-                dbc.CardHeader(
-                    html.H5(token_cg_dict[i]["Full Name"] + f' ({i})')),
-                price_col,
-                current_supply_col
-            ])
-        ], lg=(12/len(token_cg_dict.keys())), md=12)
-
+        pool_card = dbc.Col(
+            [
+                dbc.Card(
+                    [
+                        dbc.CardHeader(
+                            html.H5(tokens_dict[i]["Full Name"] + f" ({i})")
+                        ),
+                        price_col,
+                        selective_cost_col,
+                        current_supply_col,
+                    ],
+                    className="pool_card",
+                )
+            ],
+            lg=(12 / min(len(tokens_dict.keys()), 3)),
+            md=12,
+        )
         pool_cards.append(pool_card)
 
     content = [
         dbc.Row(
             dbc.Col(
-                dbc.Card([
-                    dbc.CardHeader(
-                        html.H1("State of Carbon Pools", className='page-title')),
-                ]), width=12, style={'textAlign': 'center'}
+                dbc.Card(
+                    [
+                        dbc.CardHeader(
+                            html.H1("Carbon Prices", className="page-title")
+                        ),
+                    ]
+                ),
+                width=12,
+                style={"textAlign": "center"},
             ),
         ),
-
+        dbc.Row(pool_cards[:3], style={"paddingTop": "60px"}),
+        dbc.Row(pool_cards[3:]),
         dbc.Row(
-            pool_cards, style={'paddingTop': '60px'}),
-        dbc.Row([
-            dbc.Col([
-                dbc.Card([
-                    html.H5("Historical Price",
-                            className="card-title"),
-                    dbc.CardBody(dcc.Graph(figure=fig_historical_prices))
-                ])
-            ], width=12),
-        ]),
+            [
+                dbc.Col(
+                    [
+                        dbc.Card(
+                            [
+                                html.H5("Historical Price", className="card-title"),
+                                dbc.CardBody(dcc.Graph(figure=fig_historical_prices)),
+                                dbc.CardFooter(
+                                    historical_price_note,
+                                    className="card-footer",
+                                    style={"paddingTop": "10px"},
+                                ),
+                            ]
+                        )
+                    ],
+                    width=12,
+                ),
+            ]
+        ),
     ]
     return content

--- a/src/apps/tco2_dashboard/pool.py
+++ b/src/apps/tco2_dashboard/pool.py
@@ -69,7 +69,9 @@ def create_pool_content(
                 dbc.CardBody(
                     "{:,}".format(int(retired["Quantity"].sum())), className="card-text"
                 ),
-                dbc.CardFooter(retire_note, id="klima_retire_note"),
+                dbc.CardFooter(
+                    retire_note, className="card-footer", id="klima_retire_note"
+                ),
             ],
             className="card-pool-summary",
         )
@@ -81,7 +83,9 @@ def create_pool_content(
                     className="card-title",
                 ),
                 dbc.CardBody(dcc.Graph(figure=fig_retired_over_time)),
-                dbc.CardFooter(retire_note, id="klima_retire_note"),
+                dbc.CardFooter(
+                    retire_note, className="card-footer", id="klima_retire_note"
+                ),
             ],
             className="card-graph",
         )


### PR DESCRIPTION
Reference: 
In this PR: https://github.com/KlimaDAO/dash-apps/issues/85

1) I have used the price subgraph to get prices. (https://thegraph.com/hosted-service/subgraph/originalpkbims/klimapairs-price-test)
2) Added UBO, and NBO prices
3) Added selective cost prices
4) Made changes to Homepage figure text formatting. It should show Verra Credits Issued in Billions instead of Giga.

We can update the subgraph to klima-dao official subgraph once it is completely synced.
