### PR TITLE
Filter out mispriced NCT swap

### DIFF
--- a/app-spec.yml
+++ b/app-spec.yml
@@ -28,7 +28,7 @@ services:
     health_check:
       http_path: /
       initial_delay_seconds: 60
-      timeout_seconds: 600
+      timeout_seconds: 1200
       period_seconds: 20
       success_threshold: 1
       failure_threshold: 20

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -4,7 +4,7 @@ FAILING=0
 
 for a in src/apps/tco2_dashboard/app.py; do
   module="${a////.}"
-  nohup python -m ${module%.py} &
+  nohup python -m ${module%.py} > /tmp/nohup.out 2>&1 &
   DASH_PID=$!
   sleep 30
   RESP_CODE=$(curl --head --location --write-out %{http_code} --silent --output response.txt http://127.0.0.1:8050/)
@@ -14,11 +14,11 @@ for a in src/apps/tco2_dashboard/app.py; do
   then
     echo "$a FAILED! ($RESP_CODE)"
     echo "--------------"
-    echo "Server Logs:"
-    cat nohup.out
-    echo "--------------"
     echo "UI response:"
     cat response.txt
+    echo "--------------"
+    echo "Server Logs:"
+    cat /tmp/nohup.out
     FAILING=1
   else
     echo "$a OK ($RESP_CODE)"

--- a/src/apps/tco2_dashboard/app.py
+++ b/src/apps/tco2_dashboard/app.py
@@ -796,7 +796,7 @@ def get_prices():
             # Filter out mispriced NCT swap
             if i == 'NCT':
                 df = df[df.swaps_id != MISPRICED_NCT_SWAP_ID]
-                df = df.drop('swaps_id')
+                df = df.drop('swaps_id', axis=1)
 
             # Rename and format fields
             rename_prices_map = {

--- a/src/apps/tco2_dashboard/app.py
+++ b/src/apps/tco2_dashboard/app.py
@@ -782,12 +782,23 @@ def get_prices():
                 orderBy=price_sg.Swap.timestamp,
                 orderDirection="desc",
                 where=[
-                    (price_sg.Swap.pair == tokens_dict[i]["Pair Address"]) and
-                    (price_sg.Swap.id != MISPRICED_NCT_SWAP_ID)
+                    price_sg.Swap.pair == tokens_dict[i]["Pair Address"]
                 ],
             )
 
-            df = sg.query_df([swaps.pair.id, swaps.close, swaps.timestamp])
+            # Pull swap ID for NCT
+            fields = [swaps.pair.id, swaps.close, swaps.timestamp]
+            if i == 'NCT':
+                fields.append(swaps.id)
+
+            df = sg.query_df(fields)
+
+            # Filter out mispriced NCT swap
+            if i == 'NCT':
+                df = df[df.swaps_id != MISPRICED_NCT_SWAP_ID]
+                df = df.drop('swaps_id')
+
+            # Rename and format fields
             rename_prices_map = {
                 "swaps_pair_id": f"{i}_Address",
                 "swaps_close": f"{i}_Price",

--- a/src/apps/tco2_dashboard/app.py
+++ b/src/apps/tco2_dashboard/app.py
@@ -107,6 +107,7 @@ from .constants import (
     BCT_DECIMALS,
     NCT_DECIMALS,
     MCO2_DECIMALS,
+    MISPRICED_NCT_SWAP_ID,
 )
 from pycoingecko import CoinGeckoAPI
 
@@ -780,7 +781,10 @@ def get_prices():
                 first=MAX_RECORDS,
                 orderBy=price_sg.Swap.timestamp,
                 orderDirection="desc",
-                where=[price_sg.Swap.pair == tokens_dict[i]["Pair Address"]],
+                where=[
+                    (price_sg.Swap.pair == tokens_dict[i]["Pair Address"]) and
+                    (price_sg.Swap.id != MISPRICED_NCT_SWAP_ID)
+                ],
             )
 
             df = sg.query_df([swaps.pair.id, swaps.close, swaps.timestamp])

--- a/src/apps/tco2_dashboard/constants.py
+++ b/src/apps/tco2_dashboard/constants.py
@@ -207,3 +207,5 @@ holders_rename_map = {
 GRAPH_FONT = dict(size=8, color="white", family="Inter, sans-serif")
 PIE_CHART_FONT = dict(size=12, color="white", family="Inter, sans-serif")
 TREEMAP_FONT = dict(size=12, color="white", family="Inter, sans-serif")
+
+MISPRICED_NCT_SWAP_ID = "0xdb995f975f1bfc3b2157495c47e4efb31196b2ca1679432400"


### PR DESCRIPTION
Temporary fix for spurious price reported on a tiny swap

Better approach would be to smooth the curve, so if the next point is more than 1000x different than the current price it is ignored - but ultimate question is why a tiny swap is being assigned this ridiculous price in the subgraph

Resolves #137 