### PR TITLE
Remove unused tco2-dashboard deployment

### DIFF
--- a/app-spec.yml
+++ b/app-spec.yml
@@ -36,26 +36,6 @@ services:
       repository: dash-apps
       tag: ${GITHUB_SHA}
     health_check:
-      http_path: /
-      initial_delay_seconds: 60
-      timeout_seconds: 1200
-      period_seconds: 20
-      success_threshold: 1
-      failure_threshold: 20
-    http_port: 8050
-    routes:
-      - path: /
-    instance_count: 1
-    instance_size_slug: ${DIGITALOCEAN_SIZE_SLUG}
-    name: carbon-dashboard
-    run_command: gunicorn --worker-tmp-dir /dev/shm --timeout ${GUNICORN_TIMEOUT} src.apps.tco2_dashboard.app:server
-    source_dir: /
-  - environment_slug: python
-    image:
-      registry_type: DOCR
-      repository: dash-apps
-      tag: ${GITHUB_SHA}
-    health_check:
       http_path: /api/v1
       initial_delay_seconds: 0
       timeout_seconds: 1

--- a/scripts/smoketest.sh
+++ b/scripts/smoketest.sh
@@ -2,7 +2,7 @@
 
 FAILING=0
 
-ENTRIES=(src/apps/api/app.py:/api/v1 src/apps/tco2_dashboard/app.py:/)
+ENTRIES=(src/apps/api/app.py:/api/v1)
 
 for ENTRY in ${ENTRIES[@]}; do
   ITEMS=(`echo $ENTRY | tr ":" " "`)


### PR DESCRIPTION
Now that we've migrated to data.klimadao.finance this service is no longer needed and is just wasting cycles